### PR TITLE
Removing the master/slave language

### DIFF
--- a/venv/lib/python3.7/site-packages/aws/main.py
+++ b/venv/lib/python3.7/site-packages/aws/main.py
@@ -213,7 +213,7 @@ def elb_zones_handler(parser, args):
     try:
         zones = service.zones(name, zone_names, add)
     except AttributeError:
-        # TODO Remote this try/except after https://github.com/boto/boto/pull/1492 is merged into master.
+        # TODO Remote this try/except after https://github.com/boto/boto/pull/1492 is merged into main.
         pass
 
     print elb_table(service.list(names=[name]))

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/argumentschema.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/argumentschema.py
@@ -420,7 +420,7 @@ EC2_ATTRIBUTES_SCHEMA = {
             "type": "string",
             "description":
                 "The name of the Amazon EC2 key pair that can "
-                "be used to ssh to the master node as the user 'hadoop'."
+                "be used to ssh to the main node as the user 'hadoop'."
         },
         "SubnetId": {
             "type": "string",
@@ -460,11 +460,11 @@ EC2_ATTRIBUTES_SCHEMA = {
                 " role, you must have already created it using the "
                 "<code>create-default-roles</code> command. "
         },
-        "EmrManagedMasterSecurityGroup": {
+        "EmrManagedMainSecurityGroup": {
             "type": "string",
             "description": helptext.EMR_MANAGED_MASTER_SECURITY_GROUP
         },
-        "EmrManagedSlaveSecurityGroup": {
+        "EmrManagedSubordinateSecurityGroup": {
             "type": "string",
             "description": helptext.EMR_MANAGED_SLAVE_SECURITY_GROUP
         },
@@ -472,14 +472,14 @@ EC2_ATTRIBUTES_SCHEMA = {
             "type": "string",
             "description": helptext.SERVICE_ACCESS_SECURITY_GROUP
         },
-        "AdditionalMasterSecurityGroups": {
+        "AdditionalMainSecurityGroups": {
             "type": "array",
             "description": helptext.ADDITIONAL_MASTER_SECURITY_GROUPS,
             "items": {
                 "type": "string"
             }
         },
-        "AdditionalSlaveSecurityGroups": {
+        "AdditionalSubordinateSecurityGroups": {
             "type": "array",
             "description": helptext.ADDITIONAL_SLAVE_SECURITY_GROUPS,
             "items": {
@@ -654,7 +654,7 @@ EMR_FS_SCHEMA = {
         },
         "KMSKeyId": {
             "type": "string",
-            "description": "AWS KMS's customer master key identifier",
+            "description": "AWS KMS's customer main key identifier",
         },
         "CustomProviderLocation": {
             "type": "string",

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/constants.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/constants.py
@@ -87,7 +87,7 @@ GANGLIA_INSTALL_BA_PATH = '/bootstrap-actions/install-ganglia'
 HBASE_INSTALL_BA_PATH = '/bootstrap-actions/setup-hbase'
 HBASE_PATH_HADOOP1_INSTALL_JAR = '/home/hadoop/lib/hbase-0.92.0.jar'
 HBASE_PATH_HADOOP2_INSTALL_JAR = '/home/hadoop/lib/hbase.jar'
-HBASE_INSTALL_ARG = ['emr.hbase.backup.Main', '--start-master']
+HBASE_INSTALL_ARG = ['emr.hbase.backup.Main', '--start-main']
 HBASE_JAR_PATH = '/home/hadoop/lib/hbase.jar'
 HBASE_MAIN = 'emr.hbase.backup.Main'
 

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/emrutils.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/emrutils.py
@@ -190,13 +190,13 @@ def get_cluster_state(session, parsed_globals, cluster_id):
     return data['Cluster']['Status']['State']
 
 
-def find_master_dns(session, parsed_globals, cluster_id):
+def find_main_dns(session, parsed_globals, cluster_id):
     """
-    Returns the master_instance's 'PublicDnsName'.
+    Returns the main_instance's 'PublicDnsName'.
     """
     client = get_client(session, parsed_globals)
     data = client.describe_cluster(ClusterId=cluster_id)
-    return data['Cluster']['MasterPublicDnsName']
+    return data['Cluster']['MainPublicDnsName']
 
 
 def which(program):

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/exceptions.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/exceptions.py
@@ -142,12 +142,12 @@ class LogUriError(EmrError):
            'if you enable debugging when creating a cluster.')
 
 
-class MasterDNSNotAvailableError(EmrError):
+class MainDNSNotAvailableError(EmrError):
 
     """
-    Cannot get dns of master node on the cluster.
+    Cannot get dns of main node on the cluster.
     """
-    fmt = 'Cannot get DNS of master node on the cluster. '\
+    fmt = 'Cannot get DNS of main node on the cluster. '\
           ' Please try again after some time.'
 
 

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/helptext.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/helptext.py
@@ -62,8 +62,8 @@ CLUSTER_NAME = (
 LOG_URI = (
     '<p>Specifies the location in Amazon S3 to which log files '
     'are periodically written. If a value is not provided, '
-    'logs files are not written to Amazon S3 from the master node '
-    'and are lost if the master node terminates.</p>')
+    'logs files are not written to Amazon S3 from the main node '
+    'and are lost if the main node terminates.</p>')
 
 SERVICE_ROLE = (
     '<p>Specifies an IAM service role, which Amazon EMR requires to call other AWS services '
@@ -184,16 +184,16 @@ INSTANCE_TYPE = (
     '<p>Shortcut parameter as an alternative to <code>--instance-groups</code>.'
     ' Specifies the type of Amazon EC2 instance to use in a cluster.'
     ' If used without the <code>--instance-count</code> parameter,'
-    ' the cluster consists of a single master node running on the EC2 instance type'
+    ' the cluster consists of a single main node running on the EC2 instance type'
     ' specified. When used together with <code>--instance-count</code>,'
-    ' one instance is used for the master node, and the remainder'
+    ' one instance is used for the main node, and the remainder'
     ' are used for the core node type.</p>')
 
 INSTANCE_COUNT = (
     '<p>Shortcut parameter as an alternative to <code>--instance-groups</code>'
     ' when used together with <code>--instance-type</code>. Specifies the'
     ' number of Amazon EC2 instances to create for a cluster.'
-    ' One instance is used for the master node, and the remainder'
+    ' One instance is used for the main node, and the remainder'
     ' are used for the core node type.</p>')
 
 ADDITIONAL_INFO = (
@@ -203,23 +203,23 @@ EC2_ATTRIBUTES = (
     '<p>Configures cluster and Amazon EC2 instance configurations. Accepts'
     ' the following arguments:</p>'
     '<li><code>KeyName</code> - Specifies the name of the AWS EC2 key pair that will be used for'
-    ' SSH connections to the master node and other instances on the cluster.</li>'
+    ' SSH connections to the main node and other instances on the cluster.</li>'
     '<li><code>AvailabilityZone</code> - Specifies the availability zone in which to launch'
     ' the cluster. For example, <code>us-west-1b</code>.</li>'
     '<li><code>SubnetId</code> - Specifies the VPC subnet in which to create the cluster.</li>'
     '<li><code>InstanceProfile</code> - An IAM role that allows EC2 instances to'
     ' access other AWS services, such as Amazon S3, that'
     ' are required for operations.</li>'
-    '<li><code>EmrManagedMasterSecurityGroup</code> - The security group ID of the Amazon EC2'
-    ' security group for the master node.</li>'
-    '<li><code>EmrManagedSlaveSecurityGroup</code> - The security group ID of the Amazon EC2'
-    ' security group for the slave nodes.</li>'
+    '<li><code>EmrManagedMainSecurityGroup</code> - The security group ID of the Amazon EC2'
+    ' security group for the main node.</li>'
+    '<li><code>EmrManagedSubordinateSecurityGroup</code> - The security group ID of the Amazon EC2'
+    ' security group for the subordinate nodes.</li>'
     '<li><code>ServiceAccessSecurityGroup</code> - The security group ID of the Amazon EC2 '
     'security group for Amazon EMR access to clusters in VPC private subnets.</li>'
-    '<li><code>AdditionalMasterSecurityGroups</code> - A list of additional Amazon EC2'
-    ' security group IDs for the master node.</li>'
-    '<li><code>AdditionalSlaveSecurityGroups</code> - A list of additional Amazon EC2'
-    ' security group IDs for the slave nodes.</li>')
+    '<li><code>AdditionalMainSecurityGroups</code> - A list of additional Amazon EC2'
+    ' security group IDs for the main node.</li>'
+    '<li><code>AdditionalSubordinateSecurityGroups</code> - A list of additional Amazon EC2'
+    ' security group IDs for the subordinate nodes.</li>')
 
 AUTO_TERMINATE = (
     '<p>Specifies whether the cluster should terminate after'
@@ -320,7 +320,7 @@ RESTORE_FROM_HBASE = (
 
 STEPS = (
     '<p>Specifies a list of steps to be executed by the cluster. Steps run'
-    ' only on the master node after applications are installed'
+    ' only on the main node after applications are installed'
     ' and are used to submit work to a cluster. A step can be'
     ' specified using the shorthand syntax, by referencing a JSON file'
     ' or by specifying an inline JSON structure. <code>Args</code> supplied with steps'
@@ -419,11 +419,11 @@ LIST_CLUSTERS_CREATED_BEFORE = (
 
 EMR_MANAGED_MASTER_SECURITY_GROUP = (
     '<p>The identifier of the Amazon EC2 security group '
-    'for the master node.</p>')
+    'for the main node.</p>')
 
 EMR_MANAGED_SLAVE_SECURITY_GROUP = (
     '<p>The identifier of the Amazon EC2 security group '
-    'for the slave nodes.</p>')
+    'for the subordinate nodes.</p>')
 
 SERVICE_ACCESS_SECURITY_GROUP = (
     '<p>The identifier of the Amazon EC2 security group '
@@ -431,11 +431,11 @@ SERVICE_ACCESS_SECURITY_GROUP = (
 
 ADDITIONAL_MASTER_SECURITY_GROUPS = (
     '<p> A list of additional Amazon EC2 security group IDs for '
-    'the master node</p>')
+    'the main node</p>')
 
 ADDITIONAL_SLAVE_SECURITY_GROUPS = (
     '<p>A list of additional Amazon EC2 security group IDs for '
-    'the slave nodes.</p>')
+    'the subordinate nodes.</p>')
 
 AVAILABLE_ONLY_FOR_AMI_VERSIONS = (
     'This command is only available when using Amazon EMR versions'

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/instancegroupsutils.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/instancegroupsutils.py
@@ -78,11 +78,11 @@ def validate_and_build_instance_groups(
         return build_instance_groups(instance_groups)
     else:
         instance_groups = []
-        master_ig = _build_instance_group(
+        main_ig = _build_instance_group(
             instance_type=instance_type,
             instance_count=1,
             instance_group_type="MASTER")
-        instance_groups.append(master_ig)
+        instance_groups.append(main_ig)
         if instance_count is not None and int(instance_count) > 1:
             core_ig = _build_instance_group(
                 instance_type=instance_type,

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/ssh.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/ssh.py
@@ -28,7 +28,7 @@ KEY_PAIR_FILE_HELP_TEXT = '\nA value for the variable Key Pair File ' \
 class Socks(Command):
     NAME = 'socks'
     DESCRIPTION = ('Create a socks tunnel on port 8157 from your machine '
-                   'to the master.\n%s' % KEY_PAIR_FILE_HELP_TEXT)
+                   'to the main.\n%s' % KEY_PAIR_FILE_HELP_TEXT)
     ARG_TABLE = [
         {'name': 'cluster-id', 'required': True,
          'help_text': 'Cluster Id of cluster you want to ssh into'},
@@ -38,7 +38,7 @@ class Socks(Command):
 
     def _run_main_command(self, parsed_args, parsed_globals):
         try:
-            master_dns = sshutils.validate_and_find_master_dns(
+            main_dns = sshutils.validate_and_find_main_dns(
                 session=self._session,
                 parsed_globals=parsed_globals,
                 cluster_id=parsed_args.cluster_id)
@@ -50,10 +50,10 @@ class Socks(Command):
                 command = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o',
                            'ServerAliveInterval=10', '-ND', '8157', '-i',
                            parsed_args.key_pair_file, constants.SSH_USER +
-                           '@' + master_dns]
+                           '@' + main_dns]
             else:
                 command = ['putty', '-ssh', '-i', parsed_args.key_pair_file,
-                           constants.SSH_USER + '@' + master_dns, '-N', '-D',
+                           constants.SSH_USER + '@' + main_dns, '-N', '-D',
                            '8157']
 
             print(' '.join(command))
@@ -66,18 +66,18 @@ class Socks(Command):
 
 class SSH(Command):
     NAME = 'ssh'
-    DESCRIPTION = ('SSH into master node of the cluster.\n%s' %
+    DESCRIPTION = ('SSH into main node of the cluster.\n%s' %
                    KEY_PAIR_FILE_HELP_TEXT)
     ARG_TABLE = [
         {'name': 'cluster-id', 'required': True,
          'help_text': 'Cluster Id of cluster you want to ssh into'},
         {'name': 'key-pair-file', 'required': True,
          'help_text': 'Private key file to use for login'},
-        {'name': 'command', 'help_text': 'Command to execute on Master Node'}
+        {'name': 'command', 'help_text': 'Command to execute on Main Node'}
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
-        master_dns = sshutils.validate_and_find_master_dns(
+        main_dns = sshutils.validate_and_find_main_dns(
             session=self._session,
             parsed_globals=parsed_globals,
             cluster_id=parsed_args.cluster_id)
@@ -89,12 +89,12 @@ class SSH(Command):
             command = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o',
                        'ServerAliveInterval=10', '-i',
                        parsed_args.key_pair_file, constants.SSH_USER +
-                       '@' + master_dns, '-t']
+                       '@' + main_dns, '-t']
             if parsed_args.command:
                 command.append(parsed_args.command)
         else:
             command = ['putty', '-ssh', '-i', parsed_args.key_pair_file,
-                       constants.SSH_USER + '@' + master_dns, '-t']
+                       constants.SSH_USER + '@' + main_dns, '-t']
             if parsed_args.command:
                 f.write(parsed_args.command)
                 f.write('\nread -n1 -r -p "Command completed. Press any key."')
@@ -110,7 +110,7 @@ class SSH(Command):
 
 class Put(Command):
     NAME = 'put'
-    DESCRIPTION = ('Put file onto the master node.\n%s' %
+    DESCRIPTION = ('Put file onto the main node.\n%s' %
                    KEY_PAIR_FILE_HELP_TEXT)
     ARG_TABLE = [
         {'name': 'cluster-id', 'required': True,
@@ -123,7 +123,7 @@ class Put(Command):
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
-        master_dns = sshutils.validate_and_find_master_dns(
+        main_dns = sshutils.validate_and_find_main_dns(
             session=self._session,
             parsed_globals=parsed_globals,
             cluster_id=parsed_args.cluster_id)
@@ -133,10 +133,10 @@ class Put(Command):
         if (emrutils.which('scp') or emrutils.which('scp.exe')):
             command = ['scp', '-r', '-o StrictHostKeyChecking=no',
                        '-i', parsed_args.key_pair_file, parsed_args.src,
-                       constants.SSH_USER + '@' + master_dns]
+                       constants.SSH_USER + '@' + main_dns]
         else:
             command = ['pscp', '-scp', '-r', '-i', parsed_args.key_pair_file,
-                       parsed_args.src, constants.SSH_USER + '@' + master_dns]
+                       parsed_args.src, constants.SSH_USER + '@' + main_dns]
 
         # if the instance is not terminated
         if parsed_args.dest:
@@ -150,7 +150,7 @@ class Put(Command):
 
 class Get(Command):
     NAME = 'get'
-    DESCRIPTION = ('Get file from master node.\n%s' % KEY_PAIR_FILE_HELP_TEXT)
+    DESCRIPTION = ('Get file from main node.\n%s' % KEY_PAIR_FILE_HELP_TEXT)
     ARG_TABLE = [
         {'name': 'cluster-id', 'required': True,
          'help_text': 'Cluster Id of cluster you want to get file from'},
@@ -162,7 +162,7 @@ class Get(Command):
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
-        master_dns = sshutils.validate_and_find_master_dns(
+        main_dns = sshutils.validate_and_find_main_dns(
             session=self._session,
             parsed_globals=parsed_globals,
             cluster_id=parsed_args.cluster_id)
@@ -172,10 +172,10 @@ class Get(Command):
         if (emrutils.which('scp') or emrutils.which('scp.exe')):
             command = ['scp', '-r', '-o StrictHostKeyChecking=no', '-i',
                        parsed_args.key_pair_file, constants.SSH_USER + '@' +
-                       master_dns + ':' + parsed_args.src]
+                       main_dns + ':' + parsed_args.src]
         else:
             command = ['pscp', '-scp', '-r', '-i', parsed_args.key_pair_file,
-                       constants.SSH_USER + '@' + master_dns + ':' +
+                       constants.SSH_USER + '@' + main_dns + ':' +
                        parsed_args.src]
 
         if parsed_args.dest:

--- a/venv/lib/python3.7/site-packages/awscli/customizations/emr/sshutils.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/emr/sshutils.py
@@ -21,15 +21,15 @@ from botocore.exceptions import WaiterError
 LOG = logging.getLogger(__name__)
 
 
-def validate_and_find_master_dns(session, parsed_globals, cluster_id):
+def validate_and_find_main_dns(session, parsed_globals, cluster_id):
     """
     Utility method for ssh, socks, put and get command.
     Check if the cluster to be connected to is
      terminated or being terminated.
     Check if the cluster is running.
-    Find master instance public dns of a given cluster.
-    Return the latest created master instance public dns name.
-    Throw MasterDNSNotAvailableError or ClusterTerminatedError.
+    Find main instance public dns of a given cluster.
+    Return the latest created main instance public dns name.
+    Throw MainDNSNotAvailableError or ClusterTerminatedError.
     """
     cluster_state = emrutils.get_cluster_state(
         session, parsed_globals, cluster_id)
@@ -45,9 +45,9 @@ def validate_and_find_master_dns(session, parsed_globals, cluster_id):
             print("Waiting for the cluster to start.")
         cluster_running_waiter.wait(ClusterId=cluster_id)
     except WaiterError:
-        raise exceptions.MasterDNSNotAvailableError
+        raise exceptions.MainDNSNotAvailableError
 
-    return emrutils.find_master_dns(
+    return emrutils.find_main_dns(
         session=session, cluster_id=cluster_id,
         parsed_globals=parsed_globals)
 

--- a/venv/lib/python3.7/site-packages/awscli/customizations/s3/subcommands.py
+++ b/venv/lib/python3.7/site-packages/awscli/customizations/s3/subcommands.py
@@ -213,7 +213,7 @@ SSE_KMS_KEY_ID = {
         'The AWS KMS key ID that should be used to server-side '
         'encrypt the object in S3. Note that you should only '
         'provide this parameter if KMS key ID is different the '
-        'default S3 master KMS key.'
+        'default S3 main KMS key.'
     )
 }
 

--- a/venv/lib/python3.7/site-packages/blessed/tests/accessories.py
+++ b/venv/lib/python3.7/site-packages/blessed/tests/accessories.py
@@ -76,7 +76,7 @@ class as_subprocess(object):
 
     def __call__(self, *args, **kwargs):
         pid_testrunner = os.getpid()
-        pid, master_fd = pty.fork()
+        pid, main_fd = pty.fork()
         if pid == self._CHILD_PID:
             # child process executes function, raises exception
             # if failed, causing a non-zero exit code, using the
@@ -121,7 +121,7 @@ class as_subprocess(object):
         decoder = codecs.getincrementaldecoder(self.encoding)()
         while True:
             try:
-                _exc = os.read(master_fd, 65534)
+                _exc = os.read(main_fd, 65534)
             except OSError:
                 # linux EOF
                 break
@@ -133,7 +133,7 @@ class as_subprocess(object):
         # parent process asserts exit code is 0, causing test
         # to fail if child process raised an exception/assertion
         pid, status = os.waitpid(pid, 0)
-        os.close(master_fd)
+        os.close(main_fd)
 
         # Display any output written by child process
         # (esp. any AssertionError exceptions written to stderr).

--- a/venv/lib/python3.7/site-packages/blessed/tests/test_keyboard.py
+++ b/venv/lib/python3.7/site-packages/blessed/tests/test_keyboard.py
@@ -39,7 +39,7 @@ if sys.version_info[0] == 3:
 #                    reason="TEST_QUICK specified")
 #def test_kbhit_interrupted():
 #    "kbhit() should not be interrupted with a signal handler."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:
 #        cov = init_subproc_coverage('test_kbhit_interrupted')
 #
@@ -64,12 +64,12 @@ if sys.version_info[0] == 3:
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
 #        os.kill(pid, signal.SIGWINCH)
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'complete'
@@ -81,7 +81,7 @@ if sys.version_info[0] == 3:
 #                    reason="TEST_QUICK specified")
 #def test_kbhit_interrupted_nonetype():
 #    "kbhit() should also allow interruption with timeout of None."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:
 #        cov = init_subproc_coverage('test_kbhit_interrupted_nonetype')
 #
@@ -106,13 +106,13 @@ if sys.version_info[0] == 3:
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
 #        time.sleep(0.05)
 #        os.kill(pid, signal.SIGWINCH)
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'complete'
@@ -242,7 +242,7 @@ def test_notty_kb_is_None():
 #
 #def test_keystroke_0s_cbreak_with_input():
 #    "0-second keystroke with input; Keypress should be immediately returned."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:
 #        cov = init_subproc_coverage('test_keystroke_0s_cbreak_with_input')
 #        # child pauses, writes semaphore and begins awaiting input
@@ -257,12 +257,12 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
-#        os.write(master_fd, u'x'.encode('ascii'))
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
+#        os.write(main_fd, u'x'.encode('ascii'))
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'x'
@@ -272,7 +272,7 @@ def test_notty_kb_is_None():
 #
 #def test_keystroke_cbreak_with_input_slowly():
 #    "0-second keystroke with input; Keypress should be immediately returned."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:
 #        cov = init_subproc_coverage('test_keystroke_cbreak_with_input_slowly')
 #        # child pauses, writes semaphore and begins awaiting input
@@ -290,18 +290,18 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
-#        os.write(master_fd, u'a'.encode('ascii'))
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
+#        os.write(main_fd, u'a'.encode('ascii'))
 #        time.sleep(0.1)
-#        os.write(master_fd, u'b'.encode('ascii'))
+#        os.write(main_fd, u'b'.encode('ascii'))
 #        time.sleep(0.1)
-#        os.write(master_fd, u'cdefgh'.encode('ascii'))
+#        os.write(main_fd, u'cdefgh'.encode('ascii'))
 #        time.sleep(0.1)
-#        os.write(master_fd, u'X'.encode('ascii'))
-#        read_until_semaphore(master_fd)
+#        os.write(main_fd, u'X'.encode('ascii'))
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'abcdefghX'
@@ -312,7 +312,7 @@ def test_notty_kb_is_None():
 #def test_keystroke_0s_cbreak_multibyte_utf8():
 #    "0-second keystroke with multibyte utf-8 input; should decode immediately."
 #    # utf-8 bytes represent "latin capital letter upsilon".
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_keystroke_0s_cbreak_multibyte_utf8')
 #        term = TestTerminal()
@@ -326,12 +326,12 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
-#        os.write(master_fd, u'\u01b1'.encode('utf-8'))
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
+#        os.write(main_fd, u'\u01b1'.encode('utf-8'))
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'Ʊ'
 #    assert os.WEXITSTATUS(status) == 0
@@ -342,7 +342,7 @@ def test_notty_kb_is_None():
 #                    reason="travis-ci does not handle ^C very well.")
 #def test_keystroke_0s_raw_input_ctrl_c():
 #    "0-second keystroke with raw allows receiving ^C."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_keystroke_0s_raw_input_ctrl_c')
 #        term = TestTerminal()
@@ -356,13 +356,13 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, SEND_SEMAPHORE)
+#    with echo_off(main_fd):
+#        os.write(main_fd, SEND_SEMAPHORE)
 #        # ensure child is in raw mode before sending ^C,
-#        read_until_semaphore(master_fd)
-#        os.write(master_fd, u'\x03'.encode('latin1'))
+#        read_until_semaphore(main_fd)
+#        os.write(main_fd, u'\x03'.encode('latin1'))
 #        stime = time.time()
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #    pid, status = os.waitpid(pid, 0)
 #    assert (output == u'\x03' or
 #            output == u'' and not os.isatty(0))
@@ -372,7 +372,7 @@ def test_notty_kb_is_None():
 #
 #def test_keystroke_0s_cbreak_sequence():
 #    "0-second keystroke with multibyte sequence; should decode immediately."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_keystroke_0s_cbreak_sequence')
 #        term = TestTerminal()
@@ -386,11 +386,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, u'\x1b[D'.encode('ascii'))
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, u'\x1b[D'.encode('ascii'))
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        output = read_until_eof(master_fd)
+#        output = read_until_eof(main_fd)
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'KEY_LEFT'
 #    assert os.WEXITSTATUS(status) == 0
@@ -401,7 +401,7 @@ def test_notty_kb_is_None():
 #                    reason="TEST_QUICK specified")
 #def test_keystroke_1s_cbreak_with_input():
 #    "1-second keystroke w/multibyte sequence; should return after ~1 second."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_keystroke_1s_cbreak_with_input')
 #        term = TestTerminal()
@@ -415,12 +415,12 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
 #        time.sleep(1)
-#        os.write(master_fd, u'\x1b[C'.encode('ascii'))
-#        output = read_until_eof(master_fd)
+#        os.write(main_fd, u'\x1b[C'.encode('ascii'))
+#        output = read_until_eof(main_fd)
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert output == u'KEY_RIGHT'
@@ -432,7 +432,7 @@ def test_notty_kb_is_None():
 #                    reason="TEST_QUICK specified")
 #def test_esc_delay_cbreak_035():
 #    "esc_delay will cause a single ESC (\\x1b) to delay for 0.35."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_esc_delay_cbreak_035')
 #        term = TestTerminal()
@@ -449,11 +449,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        os.write(master_fd, u'\x1b'.encode('ascii'))
-#        key_name, duration_ms = read_until_eof(master_fd).split()
+#        os.write(main_fd, u'\x1b'.encode('ascii'))
+#        key_name, duration_ms = read_until_eof(main_fd).split()
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert key_name == u'KEY_ESCAPE'
@@ -466,7 +466,7 @@ def test_notty_kb_is_None():
 #                    reason="TEST_QUICK specified")
 #def test_esc_delay_cbreak_135():
 #    "esc_delay=1.35 will cause a single ESC (\\x1b) to delay for 1.35."
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_esc_delay_cbreak_135')
 #        term = TestTerminal()
@@ -483,11 +483,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        os.write(master_fd, u'\x1b'.encode('ascii'))
-#        key_name, duration_ms = read_until_eof(master_fd).split()
+#        os.write(main_fd, u'\x1b'.encode('ascii'))
+#        key_name, duration_ms = read_until_eof(main_fd).split()
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert key_name == u'KEY_ESCAPE'
@@ -498,7 +498,7 @@ def test_notty_kb_is_None():
 #
 #def test_esc_delay_cbreak_timout_0():
 #    """esc_delay still in effect with timeout of 0 ("nonblocking")."""
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid == 0:  # child
 #        cov = init_subproc_coverage('test_esc_delay_cbreak_timout_0')
 #        term = TestTerminal()
@@ -515,11 +515,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        os.write(master_fd, u'\x1b'.encode('ascii'))
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        os.write(main_fd, u'\x1b'.encode('ascii'))
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        key_name, duration_ms = read_until_eof(master_fd).split()
+#        key_name, duration_ms = read_until_eof(main_fd).split()
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert key_name == u'KEY_ESCAPE'
@@ -530,7 +530,7 @@ def test_notty_kb_is_None():
 #
 #def test_esc_delay_cbreak_nonprefix_sequence():
 #    "ESC a (\\x1ba) will return an ESC immediately"
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid is 0:  # child
 #        cov = init_subproc_coverage('test_esc_delay_cbreak_nonprefix_sequence')
 #        term = TestTerminal()
@@ -548,11 +548,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        os.write(master_fd, u'\x1ba'.encode('ascii'))
-#        key1_name, key2, duration_ms = read_until_eof(master_fd).split()
+#        os.write(main_fd, u'\x1ba'.encode('ascii'))
+#        key1_name, key2, duration_ms = read_until_eof(main_fd).split()
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert key1_name == u'KEY_ESCAPE'
@@ -564,7 +564,7 @@ def test_notty_kb_is_None():
 #
 #def test_esc_delay_cbreak_prefix_sequence():
 #    "An unfinished multibyte sequence (\\x1b[) will delay an ESC by .35 "
-#    pid, master_fd = pty.fork()
+#    pid, main_fd = pty.fork()
 #    if pid is 0:  # child
 #        cov = init_subproc_coverage('test_esc_delay_cbreak_prefix_sequence')
 #        term = TestTerminal()
@@ -582,11 +582,11 @@ def test_notty_kb_is_None():
 #            cov.save()
 #        os._exit(0)
 #
-#    with echo_off(master_fd):
-#        read_until_semaphore(master_fd)
+#    with echo_off(main_fd):
+#        read_until_semaphore(main_fd)
 #        stime = time.time()
-#        os.write(master_fd, u'\x1b['.encode('ascii'))
-#        key1_name, key2, duration_ms = read_until_eof(master_fd).split()
+#        os.write(main_fd, u'\x1b['.encode('ascii'))
+#        key1_name, key2, duration_ms = read_until_eof(main_fd).split()
 #
 #    pid, status = os.waitpid(pid, 0)
 #    assert key1_name == u'KEY_ESCAPE'

--- a/venv/lib/python3.7/site-packages/boto/elastictranscoder/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/venv/lib/python3.7/site-packages/boto/emr/connection.py
+++ b/venv/lib/python3.7/site-packages/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/venv/lib/python3.7/site-packages/boto/emr/step.py
+++ b/venv/lib/python3.7/site-packages/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/venv/lib/python3.7/site-packages/boto/kms/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/venv/lib/python3.7/site-packages/boto/opsworks/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/venv/lib/python3.7/site-packages/boto/pyami/bootstrap.py
+++ b/venv/lib/python3.7/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/venv/lib/python3.7/site-packages/boto/rds/__init__.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/venv/lib/python3.7/site-packages/boto/rds/dbinstance.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/venv/lib/python3.7/site-packages/boto/rds/dbsnapshot.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/venv/lib/python3.7/site-packages/boto/rds2/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/venv/lib/python3.7/site-packages/boto/redshift/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/venv/lib/python3.7/site-packages/compose/cli/main.py
+++ b/venv/lib/python3.7/site-packages/compose/cli/main.py
@@ -172,7 +172,7 @@ def setup_console_handler(handler, verbose, noansi=False, level=None):
     handler.setLevel(loglevel)
 
 
-# stolen from docopt master
+# stolen from docopt main
 def parse_doc_section(name, source):
     pattern = re.compile('^([^\n]*' + name + '[^\n]*\n?(?:[ \t].*?(?:\n|$))*)',
                          re.IGNORECASE | re.MULTILINE)

--- a/venv/lib/python3.7/site-packages/dns/rdataset.py
+++ b/venv/lib/python3.7/site-packages/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         See ``dns.name.Name.choose_relativity`` for more information
         on how *origin* and *relativize* determine the way names

--- a/venv/lib/python3.7/site-packages/dns/rdtypes/ANY/SOA.py
+++ b/venv/lib/python3.7/site-packages/dns/rdtypes/ANY/SOA.py
@@ -26,7 +26,7 @@ class SOA(dns.rdata.Rdata):
 
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/venv/lib/python3.7/site-packages/dns/rrset.py
+++ b/venv/lib/python3.7/site-packages/dns/rrset.py
@@ -87,7 +87,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         See ``dns.name.Name.choose_relativity`` for more information
         on how *origin* and *relativize* determine the way names

--- a/venv/lib/python3.7/site-packages/dns/tokenizer.py
+++ b/venv/lib/python3.7/site-packages/dns/tokenizer.py
@@ -15,7 +15,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 from io import StringIO
 import sys
@@ -50,7 +50,7 @@ class UngetBufferFull(dns.exception.DNSException):
 
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     ttype: The token type
     value: The token value
@@ -150,7 +150,7 @@ class Token(object):
 
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token object is basically a (type, value) tuple.  The valid
     types are EOF, EOL, WHITESPACE, IDENTIFIER, QUOTED_STRING,

--- a/venv/lib/python3.7/site-packages/dns/zone.py
+++ b/venv/lib/python3.7/site-packages/dns/zone.py
@@ -583,9 +583,9 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
+class _MainReader(object):
 
-    """Read a DNS master file
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -642,7 +642,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -775,7 +775,7 @@ class _MasterReader(object):
     def _generate_line(self):
         # range lhs [ttl] [class] type rhs [ comment ]
         """Process one line containing the GENERATE statement from a DNS
-        master file."""
+        main file."""
         if self.current_origin is None:
             raise UnknownOrigin
 
@@ -897,7 +897,7 @@ class _MasterReader(object):
             rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -969,7 +969,7 @@ class _MasterReader(object):
                         self._generate_line()
                     else:
                         raise dns.exception.SyntaxError(
-                            "Unknown master file directive '" + c + "'")
+                            "Unknown main file directive '" + c + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -988,12 +988,12 @@ class _MasterReader(object):
 def from_text(text, origin=None, rdclass=dns.rdataclass.IN,
               relativize=True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -1022,7 +1022,7 @@ def from_text(text, origin=None, rdclass=dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -1032,12 +1032,12 @@ def from_text(text, origin=None, rdclass=dns.rdataclass.IN,
 def from_file(f, origin=None, rdclass=dns.rdataclass.IN,
               relativize=True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.

--- a/venv/lib/python3.7/site-packages/docker/types/services.py
+++ b/venv/lib/python3.7/site-packages/docker/types/services.py
@@ -200,7 +200,7 @@ class Mount(dict):
         consistency (string): The consistency requirement for the mount. One of
         ``default```, ``consistent``, ``cached``, ``delegated``.
         propagation (string): A propagation mode with the value ``[r]private``,
-          ``[r]shared``, or ``[r]slave``. Only valid for the ``bind`` type.
+          ``[r]shared``, or ``[r]subordinate``. Only valid for the ``bind`` type.
         no_copy (bool): False if the volume should be populated with the data
           from the target. Default: ``False``. Only valid for the ``volume``
           type.

--- a/venv/lib/python3.7/site-packages/docutils/parsers/rst/states.py
+++ b/venv/lib/python3.7/site-packages/docutils/parsers/rst/states.py
@@ -137,7 +137,7 @@ class Struct:
 class RSTStateMachine(StateMachineWS):
 
     """
-    reStructuredText's master StateMachine.
+    reStructuredText's main StateMachine.
 
     The entry point to reStructuredText parsing is the `run()` method.
     """

--- a/venv/lib/python3.7/site-packages/docutils/parsers/rst/tableparser.py
+++ b/venv/lib/python3.7/site-packages/docutils/parsers/rst/tableparser.py
@@ -534,11 +534,11 @@ class SimpleTableParser(TableParser):
                 self.table[first_body_row:])
 
 
-def update_dict_of_lists(master, newdata):
+def update_dict_of_lists(main, newdata):
     """
-    Extend the list values of `master` with those from `newdata`.
+    Extend the list values of `main` with those from `newdata`.
 
     Both parameters must be dictionaries containing list values.
     """
     for key, values in list(newdata.items()):
-        master.setdefault(key, []).extend(values)
+        main.setdefault(key, []).extend(values)

--- a/venv/lib/python3.7/site-packages/docutils/utils/math/math2html.py
+++ b/venv/lib/python3.7/site-packages/docutils/utils/math/math2html.py
@@ -114,7 +114,7 @@ class BibStylesConfig(object):
       '@incollection':'$authors: <i>$title</i>{ in <i>$booktitle</i>{ ($editor, ed.)}}.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@inproceedings':'$authors: “$title”, <i>$booktitle</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@manual':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
-      '@mastersthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
+      '@mainsthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@misc':'$authors: <i>$title</i>.{{ $publisher,}{ $howpublished,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@phdthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@proceedings':'$authors: “$title”, <i>$journal</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
@@ -3177,7 +3177,7 @@ class NumberCounter(object):
   name = None
   value = None
   mode = None
-  master = None
+  main = None
 
   letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   symbols = NumberingConfig.sequence['symbols']
@@ -3260,25 +3260,25 @@ class NumberCounter(object):
     return result
 
 class DependentCounter(NumberCounter):
-  "A counter which depends on another one (the master)."
+  "A counter which depends on another one (the main)."
 
-  def setmaster(self, master):
-    "Set the master counter."
-    self.master = master
-    self.last = self.master.getvalue()
+  def setmain(self, main):
+    "Set the main counter."
+    self.main = main
+    self.last = self.main.getvalue()
     return self
 
   def getnext(self):
-    "Increase or, if the master counter has changed, restart."
-    if self.last != self.master.getvalue():
+    "Increase or, if the main counter has changed, restart."
+    if self.last != self.main.getvalue():
       self.reset()
     value = NumberCounter.getnext(self)
-    self.last = self.master.getvalue()
+    self.last = self.main.getvalue()
     return value
 
   def getvalue(self):
-    "Get the value of the combined counter: master.dependent."
-    return self.master.getvalue() + '.' + NumberCounter.getvalue(self)
+    "Get the value of the combined counter: main.dependent."
+    return self.main.getvalue() + '.' + NumberCounter.getvalue(self)
 
 class NumberGenerator(object):
   "A number generator for unique sequences and hierarchical structures. Used in:"
@@ -3366,22 +3366,22 @@ class NumberGenerator(object):
     if self.isnumbered(type) and self.getlevel(type) > 1:
       index = self.orderedlayouts.index(type)
       above = self.orderedlayouts[index - 1]
-      master = self.getcounter(above)
-      return self.createdependent(type, master)
+      main = self.getcounter(above)
+      return self.createdependent(type, main)
     counter = NumberCounter(type)
     if self.isroman(type):
       counter.setmode('I')
     return counter
 
-  def getdependentcounter(self, type, master):
+  def getdependentcounter(self, type, main):
     "Get (or create) a counter of the given type that depends on another."
-    if not type in self.counters or not self.counters[type].master:
-      self.counters[type] = self.createdependent(type, master)
+    if not type in self.counters or not self.counters[type].main:
+      self.counters[type] = self.createdependent(type, main)
     return self.counters[type]
 
-  def createdependent(self, type, master):
-    "Create a dependent counter given the master."
-    return DependentCounter(type).setmaster(master)
+  def createdependent(self, type, main):
+    "Create a dependent counter given the main."
+    return DependentCounter(type).setmain(main)
 
   def startappendix(self):
     "Start appendices here."

--- a/venv/lib/python3.7/site-packages/docutils/writers/odf_odt/__init__.py
+++ b/venv/lib/python3.7/site-packages/docutils/writers/odf_odt/__init__.py
@@ -1082,7 +1082,7 @@ class ODFTranslator(nodes.GenericNodeVisitor):
         el1 = SubElement(
             self.automatic_styles, 'style:style', attrib={
                 'style:name': style_name,
-                'style:master-page-name': "rststyle-pagedefault",
+                'style:main-page-name': "rststyle-pagedefault",
                 'style:family': "paragraph",
             }, nsdict=SNSD)
         if current_style:
@@ -1140,22 +1140,22 @@ class ODFTranslator(nodes.GenericNodeVisitor):
     def add_header_footer(self, root_el):
         automatic_styles = root_el.find(
             '{%s}automatic-styles' % SNSD['office'])
-        path = '{%s}master-styles' % (NAME_SPACE_1, )
-        master_el = root_el.find(path)
-        if master_el is None:
+        path = '{%s}main-styles' % (NAME_SPACE_1, )
+        main_el = root_el.find(path)
+        if main_el is None:
             return
-        path = '{%s}master-page' % (SNSD['style'], )
-        master_el_container = master_el.findall(path)
-        master_el = None
+        path = '{%s}main-page' % (SNSD['style'], )
+        main_el_container = main_el.findall(path)
+        main_el = None
         target_attrib = '{%s}name' % (SNSD['style'], )
         target_name = self.rststyle('pagedefault')
-        for el in master_el_container:
+        for el in main_el_container:
             if el.get(target_attrib) == target_name:
-                master_el = el
+                main_el = el
                 break
-        if master_el is None:
+        if main_el is None:
             return
-        el1 = master_el
+        el1 = main_el
         if self.header_content or self.settings.custom_header:
             if WhichElementTree == 'lxml':
                 el2 = SubElement(el1, 'style:header', nsdict=SNSD)

--- a/venv/lib/python3.7/site-packages/ebcli/resources/strings.py
+++ b/venv/lib/python3.7/site-packages/ebcli/resources/strings.py
@@ -587,7 +587,7 @@ prompts = {
                      '**terminated** and new instances will be created. '
                      'The environment will be temporarily unavailable.',
     'rds.username': 'Enter an RDS DB username (default is "ebroot")',
-    'rds.password': 'Enter an RDS DB master password',
+    'rds.password': 'Enter an RDS DB main password',
     'vpc.id': 'Enter the VPC ID',
     'vpc.publicip': 'Do you want to associate a public IP address?',
     'vpc.ec2subnets': 'Enter a comma-separated list of Amazon EC2 subnets',

--- a/venv/lib/python3.7/site-packages/gunicorn/arbiter.py
+++ b/venv/lib/python3.7/site-packages/gunicorn/arbiter.py
@@ -63,8 +63,8 @@ class Arbiter(object):
         self.systemd = False
         self.worker_age = 0
         self.reexec_pid = 0
-        self.master_pid = 0
-        self.master_name = "Master"
+        self.main_pid = 0
+        self.main_name = "Main"
 
         cwd = util.getcwd()
 
@@ -126,14 +126,14 @@ class Arbiter(object):
         self.log.info("Starting gunicorn %s", __version__)
 
         if 'GUNICORN_PID' in os.environ:
-            self.master_pid = int(os.environ.get('GUNICORN_PID'))
+            self.main_pid = int(os.environ.get('GUNICORN_PID'))
             self.proc_name = self.proc_name + ".2"
-            self.master_name = "Master.2"
+            self.main_name = "Main.2"
 
         self.pid = os.getpid()
         if self.cfg.pidfile is not None:
             pidname = self.cfg.pidfile
-            if self.master_pid != 0:
+            if self.main_pid != 0:
                 pidname += ".2"
             self.pidfile = Pidfile(pidname)
             self.pidfile.create(self.pid)
@@ -149,7 +149,7 @@ class Arbiter(object):
                 fds = range(systemd.SD_LISTEN_FDS_START,
                             systemd.SD_LISTEN_FDS_START + listen_fds)
 
-            elif self.master_pid:
+            elif self.main_pid:
                 fds = []
                 for fd in os.environ.pop('GUNICORN_FD').split(','):
                     fds.append(int(fd))
@@ -169,8 +169,8 @@ class Arbiter(object):
 
     def init_signals(self):
         """\
-        Initialize master signal handling. Most of the signals
-        are queued. Child signals only wake up the master.
+        Initialize main signal handling. Most of the signals
+        are queued. Child signals only wake up the main.
         """
         # close old PIPE
         for p in self.PIPE:
@@ -195,15 +195,15 @@ class Arbiter(object):
             self.wakeup()
 
     def run(self):
-        "Main master loop."
+        "Main main loop."
         self.start()
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle("main [%s]" % self.proc_name)
 
         try:
             self.manage_workers()
 
             while True:
-                self.maybe_promote_master()
+                self.maybe_promote_main()
 
                 sig = self.SIG_QUEUE.pop(0) if self.SIG_QUEUE else None
                 if sig is None:
@@ -252,7 +252,7 @@ class Arbiter(object):
         - Start the new worker processes with a new configuration
         - Gracefully shutdown the old worker processes
         """
-        self.log.info("Hang up: %s", self.master_name)
+        self.log.info("Hang up: %s", self.main_name)
         self.reload()
 
     def handle_term(self):
@@ -298,8 +298,8 @@ class Arbiter(object):
     def handle_usr2(self):
         """\
         SIGUSR2 handling.
-        Creates a new master/worker set as a slave of the current
-        master without affecting old workers. Use this to do live
+        Creates a new main/worker set as a subordinate of the current
+        main without affecting old workers. Use this to do live
         deployment with the ability to backout a change.
         """
         self.reexec()
@@ -313,22 +313,22 @@ class Arbiter(object):
         else:
             self.log.debug("SIGWINCH ignored. Not daemonized")
 
-    def maybe_promote_master(self):
-        if self.master_pid == 0:
+    def maybe_promote_main(self):
+        if self.main_pid == 0:
             return
 
-        if self.master_pid != os.getppid():
-            self.log.info("Master has been promoted.")
-            # reset master infos
-            self.master_name = "Master"
-            self.master_pid = 0
+        if self.main_pid != os.getppid():
+            self.log.info("Main has been promoted.")
+            # reset main infos
+            self.main_name = "Main"
+            self.main_pid = 0
             self.proc_name = self.cfg.proc_name
             del os.environ['GUNICORN_PID']
             # rename the pidfile
             if self.pidfile is not None:
                 self.pidfile.rename(self.cfg.pidfile)
             # reset proctitle
-            util._setproctitle("master [%s]" % self.proc_name)
+            util._setproctitle("main [%s]" % self.proc_name)
 
     def wakeup(self):
         """\
@@ -343,7 +343,7 @@ class Arbiter(object):
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
         self.stop()
-        self.log.info("Shutting down: %s", self.master_name)
+        self.log.info("Shutting down: %s", self.main_name)
         if reason is not None:
             self.log.info("Reason: %s", reason)
         if self.pidfile is not None:
@@ -378,7 +378,7 @@ class Arbiter(object):
         killed gracefully  (ie. trying to wait for the current connection)
         """
 
-        unlink = self.reexec_pid == self.master_pid == 0 and not self.systemd
+        unlink = self.reexec_pid == self.main_pid == 0 and not self.systemd
         sock.close_sockets(self.LISTENERS, unlink)
 
         self.LISTENERS = []
@@ -396,17 +396,17 @@ class Arbiter(object):
 
     def reexec(self):
         """\
-        Relaunch the master and workers.
+        Relaunch the main and workers.
         """
         if self.reexec_pid != 0:
             self.log.warning("USR2 signal ignored. Child exists.")
             return
 
-        if self.master_pid != 0:
+        if self.main_pid != 0:
             self.log.warning("USR2 signal ignored. Parent exists.")
             return
 
-        master_pid = os.getpid()
+        main_pid = os.getpid()
         self.reexec_pid = os.fork()
         if self.reexec_pid != 0:
             return
@@ -414,7 +414,7 @@ class Arbiter(object):
         self.cfg.pre_exec(self)
 
         environ = self.cfg.env_orig.copy()
-        environ['GUNICORN_PID'] = str(master_pid)
+        environ['GUNICORN_PID'] = str(main_pid)
 
         if self.systemd:
             environ['LISTEN_PID'] = str(os.getpid())
@@ -474,7 +474,7 @@ class Arbiter(object):
             self.pidfile.create(self.pid)
 
         # set new proc_name
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle("main [%s]" % self.proc_name)
 
         # spawn new workers
         for _ in range(self.cfg.workers):
@@ -609,7 +609,7 @@ class Arbiter(object):
         Spawn new workers as needed.
 
         This is where a worker process leaves the main loop
-        of the master process.
+        of the main process.
         """
 
         for _ in range(self.num_workers - len(self.WORKERS.keys())):

--- a/venv/lib/python3.7/site-packages/gunicorn/config.py
+++ b/venv/lib/python3.7/site-packages/gunicorn/config.py
@@ -1546,7 +1546,7 @@ class OnStarting(Setting):
         pass
     default = staticmethod(on_starting)
     desc = """\
-        Called just before the master process is initialized.
+        Called just before the main process is initialized.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1683,7 +1683,7 @@ class PreExec(Setting):
         pass
     default = staticmethod(pre_exec)
     desc = """\
-        Called just before a new master process is forked.
+        Called just before a new main process is forked.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1733,7 +1733,7 @@ class ChildExit(Setting):
         pass
     default = staticmethod(child_exit)
     desc = """\
-        Called just after a worker has been exited, in the master process.
+        Called just after a worker has been exited, in the main process.
 
         The callable needs to accept two instance variables for the Arbiter and
         the just-exited Worker.

--- a/venv/lib/python3.7/site-packages/gunicorn/workers/base.py
+++ b/venv/lib/python3.7/site-packages/gunicorn/workers/base.py
@@ -64,7 +64,7 @@ class Worker(object):
         """\
         Your worker subclass must arrange to have this method called
         once every ``self.timeout`` seconds. If you fail in accomplishing
-        this task, the master process will murder your workers.
+        this task, the main process will murder your workers.
         """
         self.tmp.notify()
 

--- a/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_internal/vcs/git.py
+++ b/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_internal/vcs/git.py
@@ -242,7 +242,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.resolve_revision(dest, url, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
@@ -565,9 +565,9 @@ class WorkingSet:
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3124,9 +3124,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3136,7 +3136,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/venv/lib/python3.7/site-packages/pycparser/ply/lex.py
+++ b/venv/lib/python3.7/site-packages/pycparser/ply/lex.py
@@ -114,12 +114,12 @@ class NullLogger(object):
 
 class Lexer:
     def __init__(self):
-        self.lexre = None             # Master regular expression. This is a list of
+        self.lexre = None             # Main regular expression. This is a list of
                                       # tuples (re, findex) where re is a compiled
                                       # regular expression and findex is a list
                                       # mapping regex group numbers to rules
         self.lexretext = None         # Current regular expression strings
-        self.lexstatere = {}          # Dictionary mapping lexer states to master regexs
+        self.lexstatere = {}          # Dictionary mapping lexer states to main regexs
         self.lexstateretext = {}      # Dictionary mapping lexer states to regex strings
         self.lexstaterenames = {}     # Dictionary mapping lexer states to symbol names
         self.lexstate = 'INITIAL'     # Current lexer state
@@ -484,13 +484,13 @@ def _names_to_funcs(namelist, fdict):
     return result
 
 # -----------------------------------------------------------------------------
-# _form_master_re()
+# _form_main_re()
 #
 # This function takes a list of all of the regex components and attempts to
-# form the master regular expression.  Given limitations in the Python re
-# module, it may be necessary to break the master regex into separate expressions.
+# form the main regular expression.  Given limitations in the Python re
+# module, it may be necessary to break the main regex into separate expressions.
 # -----------------------------------------------------------------------------
-def _form_master_re(relist, reflags, ldict, toknames):
+def _form_main_re(relist, reflags, ldict, toknames):
     if not relist:
         return []
     regex = '|'.join(relist)
@@ -518,8 +518,8 @@ def _form_master_re(relist, reflags, ldict, toknames):
         m = int(len(relist)/2)
         if m == 0:
             m = 1
-        llist, lre, lnames = _form_master_re(relist[:m], reflags, ldict, toknames)
-        rlist, rre, rnames = _form_master_re(relist[m:], reflags, ldict, toknames)
+        llist, lre, lnames = _form_main_re(relist[:m], reflags, ldict, toknames)
+        rlist, rre, rnames = _form_main_re(relist[m:], reflags, ldict, toknames)
         return (llist+rlist), (lre+rre), (lnames+rnames)
 
 # -----------------------------------------------------------------------------
@@ -943,7 +943,7 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
     stateinfo = linfo.stateinfo
 
     regexs = {}
-    # Build the master regular expressions
+    # Build the main regular expressions
     for state in stateinfo:
         regex_list = []
 
@@ -963,13 +963,13 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
 
         regexs[state] = regex_list
 
-    # Build the master regular expressions
+    # Build the main regular expressions
 
     if debug:
         debuglog.info('lex: ==== MASTER REGEXS FOLLOW ====')
 
     for state in regexs:
-        lexre, re_text, re_names = _form_master_re(regexs[state], reflags, ldict, linfo.toknames)
+        lexre, re_text, re_names = _form_main_re(regexs[state], reflags, ldict, linfo.toknames)
         lexobj.lexstatere[state] = lexre
         lexobj.lexstateretext[state] = re_text
         lexobj.lexstaterenames[state] = re_names

--- a/venv/lib/python3.7/site-packages/pymongo/auth.py
+++ b/venv/lib/python3.7/site-packages/pymongo/auth.py
@@ -528,7 +528,7 @@ def _authenticate_default(credentials, sock_info):
     if sock_info.max_wire_version >= 7:
         source = credentials.source
         cmd = SON([
-            ('ismaster', 1),
+            ('ismain', 1),
             ('saslSupportedMechs', source + '.' + credentials.username)])
         mechs = sock_info.command(
             source, cmd, publish_events=False).get('saslSupportedMechs', [])

--- a/venv/lib/python3.7/site-packages/pymongo/change_stream.py
+++ b/venv/lib/python3.7/site-packages/pymongo/change_stream.py
@@ -107,7 +107,7 @@ class ChangeStream(object):
         """
         read_preference = self._target._read_preference_for(session)
         client = self._database.client
-        with client._socket_for_reads(read_preference) as (sock_info, slave_ok):
+        with client._socket_for_reads(read_preference) as (sock_info, subordinate_ok):
             pipeline = self._full_pipeline()
             cmd = SON([("aggregate", self._aggregation_target),
                        ("pipeline", pipeline),
@@ -116,7 +116,7 @@ class ChangeStream(object):
             result = sock_info.command(
                 self._database.name,
                 cmd,
-                slave_ok,
+                subordinate_ok,
                 read_preference,
                 self._target.codec_options,
                 parse_write_concern_error=True,

--- a/venv/lib/python3.7/site-packages/pymongo/collection.py
+++ b/venv/lib/python3.7/site-packages/pymongo/collection.py
@@ -195,7 +195,7 @@ class Collection(common.BaseObject):
     def _socket_for_writes(self):
         return self.__database.client._socket_for_writes()
 
-    def _command(self, sock_info, command, slave_ok=False,
+    def _command(self, sock_info, command, subordinate_ok=False,
                  read_preference=None,
                  codec_options=None, check=True, allowable_errors=None,
                  read_concern=None,
@@ -208,7 +208,7 @@ class Collection(common.BaseObject):
         :Parameters:
           - `sock_info` - A SocketInfo instance.
           - `command` - The command itself, as a SON instance.
-          - `slave_ok`: whether to set the SlaveOkay wire protocol bit.
+          - `subordinate_ok`: whether to set the SubordinateOkay wire protocol bit.
           - `codec_options` (optional) - An instance of
             :class:`~bson.codec_options.CodecOptions`.
           - `check`: raise OperationFailure if there are errors
@@ -230,7 +230,7 @@ class Collection(common.BaseObject):
             return sock_info.command(
                 self.__database.name,
                 command,
-                slave_ok,
+                subordinate_ok,
                 read_preference or self._read_preference_for(session),
                 codec_options or self.codec_options,
                 check,
@@ -1420,7 +1420,7 @@ class Collection(common.BaseObject):
            Added the `cursor_type`, `oplog_replay`, and `modifiers` options.
            Removed the `network_timeout`, `read_preference`, `tag_sets`,
            `secondary_acceptable_latency_ms`, `max_scan`, `snapshot`,
-           `tailable`, `await_data`, `exhaust`, `as_class`, and slave_okay
+           `tailable`, `await_data`, `exhaust`, `as_class`, and subordinate_okay
            parameters. Removed `compile_re` option: PyMongo now always
            represents BSON regular expressions as :class:`~bson.regex.Regex`
            objects. Use :meth:`~bson.regex.Regex.try_compile` to attempt to
@@ -1536,13 +1536,13 @@ class Collection(common.BaseObject):
                    ('numCursors', num_cursors)])
         cmd.update(kwargs)
 
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
             # We call sock_info.command here directly, instead of
             # calling self._command to avoid using an implicit session.
             result = sock_info.command(
                 self.__database.name,
                 cmd,
-                slave_ok,
+                subordinate_ok,
                 self._read_preference_for(session),
                 self.codec_options,
                 read_concern=self.read_concern,
@@ -1560,11 +1560,11 @@ class Collection(common.BaseObject):
 
     def _count(self, cmd, collation=None, session=None):
         """Internal count helper."""
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
             res = self._command(
                 sock_info,
                 cmd,
-                slave_ok,
+                subordinate_ok,
                 allowable_errors=["ns missing"],
                 codec_options=self.__write_response_codec_options,
                 read_concern=self.read_concern,
@@ -1575,12 +1575,12 @@ class Collection(common.BaseObject):
         return int(res["n"])
 
     def _aggregate_one_result(
-            self, sock_info, slave_ok, cmd, collation=None, session=None):
+            self, sock_info, subordinate_ok, cmd, collation=None, session=None):
         """Internal helper to run an aggregate that returns a single result."""
         result = self._command(
             sock_info,
             cmd,
-            slave_ok,
+            subordinate_ok,
             codec_options=self.__write_response_codec_options,
             read_concern=self.read_concern,
             collation=collation,
@@ -1680,9 +1680,9 @@ class Collection(common.BaseObject):
             kwargs["hint"] = helpers._index_document(kwargs["hint"])
         collation = validate_collation_or_none(kwargs.pop('collation', None))
         cmd.update(kwargs)
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
             result = self._aggregate_one_result(
-                sock_info, slave_ok, cmd, collation, session)
+                sock_info, subordinate_ok, cmd, collation, session)
         if not result:
             return 0
         return result['n']
@@ -2136,12 +2136,12 @@ class Collection(common.BaseObject):
         coll = self.with_options(codec_options=codec_options,
                                  read_preference=ReadPreference.PRIMARY)
         sock_ctx, read_pref = self._socket_for_primary_reads(session)
-        with sock_ctx as (sock_info, slave_ok):
+        with sock_ctx as (sock_info, subordinate_ok):
             cmd = SON([("listIndexes", self.__name), ("cursor", {})])
             if sock_info.max_wire_version > 2:
                 with self.__database.client._tmp_session(session, False) as s:
                     try:
-                        cursor = self._command(sock_info, cmd, slave_ok,
+                        cursor = self._command(sock_info, cmd, subordinate_ok,
                                                read_pref,
                                                codec_options,
                                                session=s)["cursor"]
@@ -2157,7 +2157,7 @@ class Collection(common.BaseObject):
             else:
                 res = message._first_batch(
                     sock_info, self.__database.name, "system.indexes",
-                    {"ns": self.__full_name}, 0, slave_ok, codec_options,
+                    {"ns": self.__full_name}, 0, subordinate_ok, codec_options,
                     read_pref, cmd,
                     self.database.client._event_listeners)
                 cursor = res["cursor"]
@@ -2263,7 +2263,7 @@ class Collection(common.BaseObject):
             "batchSize", kwargs.pop("batchSize", None))
         # If the server does not support the "cursor" option we
         # ignore useCursor and batchSize.
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
             dollar_out = pipeline and '$out' in pipeline[-1]
             if use_cursor:
                 if "cursor" not in kwargs:
@@ -2293,7 +2293,7 @@ class Collection(common.BaseObject):
             result = sock_info.command(
                 self.__database.name,
                 cmd,
-                slave_ok,
+                subordinate_ok,
                 self._read_preference_for(session),
                 self.codec_options,
                 parse_write_concern_error=True,
@@ -2557,8 +2557,8 @@ class Collection(common.BaseObject):
         collation = validate_collation_or_none(kwargs.pop('collation', None))
         cmd.update(kwargs)
 
-        with self._socket_for_reads(session=None) as (sock_info, slave_ok):
-            return self._command(sock_info, cmd, slave_ok,
+        with self._socket_for_reads(session=None) as (sock_info, subordinate_ok):
+            return self._command(sock_info, cmd, subordinate_ok,
                                  collation=collation)["retval"]
 
     def rename(self, new_name, session=None, **kwargs):
@@ -2660,8 +2660,8 @@ class Collection(common.BaseObject):
             kwargs["query"] = filter
         collation = validate_collation_or_none(kwargs.pop('collation', None))
         cmd.update(kwargs)
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
-            return self._command(sock_info, cmd, slave_ok,
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
+            return self._command(sock_info, cmd, subordinate_ok,
                                  read_concern=self.read_concern,
                                  collation=collation, session=session)["values"]
 
@@ -2733,7 +2733,7 @@ class Collection(common.BaseObject):
 
         inline = 'inline' in cmd['out']
         sock_ctx, read_pref = self._socket_for_primary_reads(session)
-        with sock_ctx as (sock_info, slave_ok):
+        with sock_ctx as (sock_info, subordinate_ok):
             if (sock_info.max_wire_version >= 4 and 'readConcern' not in cmd and
                     inline):
                 read_concern = self.read_concern
@@ -2745,7 +2745,7 @@ class Collection(common.BaseObject):
                 write_concern = None
 
             response = self._command(
-                sock_info, cmd, slave_ok, read_pref,
+                sock_info, cmd, subordinate_ok, read_pref,
                 read_concern=read_concern,
                 write_concern=write_concern,
                 collation=collation, session=session)
@@ -2800,13 +2800,13 @@ class Collection(common.BaseObject):
                    ("out", {"inline": 1})])
         collation = validate_collation_or_none(kwargs.pop('collation', None))
         cmd.update(kwargs)
-        with self._socket_for_reads(session) as (sock_info, slave_ok):
+        with self._socket_for_reads(session) as (sock_info, subordinate_ok):
             if sock_info.max_wire_version >= 4 and 'readConcern' not in cmd:
-                res = self._command(sock_info, cmd, slave_ok,
+                res = self._command(sock_info, cmd, subordinate_ok,
                                     read_concern=self.read_concern,
                                     collation=collation, session=session)
             else:
-                res = self._command(sock_info, cmd, slave_ok,
+                res = self._command(sock_info, cmd, subordinate_ok,
                                     collation=collation, session=session)
 
         if full_response:

--- a/venv/lib/python3.7/site-packages/pymongo/command_cursor.py
+++ b/venv/lib/python3.7/site-packages/pymongo/command_cursor.py
@@ -22,7 +22,7 @@ from bson.py3compat import integer_types
 from pymongo import helpers
 from pymongo.errors import (AutoReconnect,
                             InvalidOperation,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure)
 from pymongo.message import (_convert_exception,
                              _CursorAddress,
@@ -165,8 +165,8 @@ class CommandCursor(object):
                     duration(), exc.details, "getMore", rqst_id, self.__address)
 
             raise
-        except NotMasterError as exc:
-            # Don't send kill cursors to another server after a "not master"
+        except NotMainError as exc:
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             kill()
 

--- a/venv/lib/python3.7/site-packages/pymongo/common.py
+++ b/venv/lib/python3.7/site-packages/pymongo/common.py
@@ -54,7 +54,7 @@ MIN_SUPPORTED_SERVER_VERSION = "2.6"
 MIN_SUPPORTED_WIRE_VERSION = 2
 MAX_SUPPORTED_WIRE_VERSION = 5
 
-# Frequency to call ismaster on servers, in seconds.
+# Frequency to call ismain on servers, in seconds.
 HEARTBEAT_FREQUENCY = 10
 
 # Frequency to process kill-cursors, in seconds. See MongoClient.close_cursor.
@@ -69,7 +69,7 @@ EVENTS_QUEUE_FREQUENCY = 1
 # longest it is willing to wait for a new primary to be found.
 SERVER_SELECTION_TIMEOUT = 30
 
-# Spec requires at least 500ms between ismaster calls.
+# Spec requires at least 500ms between ismain calls.
 MIN_HEARTBEAT_INTERVAL = 0.5
 
 # Default connectTimeout in seconds.
@@ -114,13 +114,13 @@ def partition_node(node):
 
 
 def clean_node(node):
-    """Split and normalize a node name from an ismaster response."""
+    """Split and normalize a node name from an ismain response."""
     host, port = partition_node(node)
 
     # Normalize hostname to lowercase, since DNS is case-insensitive:
     # http://tools.ietf.org/html/rfc4343
     # This prevents useless rediscovery if "foo.com" is in the seed list but
-    # "FOO.com" is in the ismaster response.
+    # "FOO.com" is in the ismain response.
     return host.lower(), port
 
 

--- a/venv/lib/python3.7/site-packages/pymongo/compression_support.py
+++ b/venv/lib/python3.7/site-packages/pymongo/compression_support.py
@@ -31,7 +31,7 @@ except ImportError:
 from pymongo.monitoring import _SENSITIVE_COMMANDS
 
 _SUPPORTED_COMPRESSORS = set(["snappy", "zlib"])
-_NO_COMPRESSION = set(['ismaster'])
+_NO_COMPRESSION = set(['ismain'])
 _NO_COMPRESSION.update(_SENSITIVE_COMMANDS)
 
 

--- a/venv/lib/python3.7/site-packages/pymongo/cursor.py
+++ b/venv/lib/python3.7/site-packages/pymongo/cursor.py
@@ -32,7 +32,7 @@ from pymongo.collation import validate_collation_or_none
 from pymongo.errors import (AutoReconnect,
                             ConnectionFailure,
                             InvalidOperation,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure)
 from pymongo.message import (_convert_exception,
                              _CursorAddress,
@@ -44,7 +44,7 @@ from pymongo.read_preferences import ReadPreference
 
 _QUERY_OPTIONS = {
     "tailable_cursor": 2,
-    "slave_okay": 4,
+    "subordinate_okay": 4,
     "oplog_replay": 8,
     "no_timeout": 16,
     "await_data": 32,
@@ -997,8 +997,8 @@ class Cursor(object):
             if self.__query_flags & _QUERY_OPTIONS["tailable_cursor"]:
                 return
             raise
-        except NotMasterError as exc:
-            # Don't send kill cursors to another server after a "not master"
+        except NotMainError as exc:
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             self.__killed = True
 

--- a/venv/lib/python3.7/site-packages/pymongo/database.py
+++ b/venv/lib/python3.7/site-packages/pymongo/database.py
@@ -489,7 +489,7 @@ class Database(common.BaseObject):
             batch_size, collation, start_at_operation_time, session
         )
 
-    def _command(self, sock_info, command, slave_ok=False, value=1, check=True,
+    def _command(self, sock_info, command, subordinate_ok=False, value=1, check=True,
                  allowable_errors=None, read_preference=ReadPreference.PRIMARY,
                  codec_options=DEFAULT_CODEC_OPTIONS,
                  write_concern=None,
@@ -503,7 +503,7 @@ class Database(common.BaseObject):
             return sock_info.command(
                 self.__name,
                 command,
-                slave_ok,
+                subordinate_ok,
                 read_preference,
                 codec_options,
                 check,
@@ -608,12 +608,12 @@ class Database(common.BaseObject):
             read_preference = ((session and session._txn_read_preference())
                                or ReadPreference.PRIMARY)
         with self.__client._socket_for_reads(
-                read_preference) as (sock_info, slave_ok):
-            return self._command(sock_info, command, slave_ok, value,
+                read_preference) as (sock_info, subordinate_ok):
+            return self._command(sock_info, command, subordinate_ok, value,
                                  check, allowable_errors, read_preference,
                                  codec_options, session=session, **kwargs)
 
-    def _list_collections(self, sock_info, slave_okay, session,
+    def _list_collections(self, sock_info, subordinate_okay, session,
                           read_preference, **kwargs):
         """Internal listCollections helper."""
 
@@ -626,7 +626,7 @@ class Database(common.BaseObject):
             with self.__client._tmp_session(
                     session, close=False) as tmp_session:
                 cursor = self._command(
-                    sock_info, cmd, slave_okay,
+                    sock_info, cmd, subordinate_okay,
                     read_preference=read_preference,
                     session=tmp_session)["cursor"]
                 return CommandCursor(
@@ -648,7 +648,7 @@ class Database(common.BaseObject):
             cmd = SON([("aggregate", "system.namespaces"),
                        ("pipeline", pipeline),
                        ("cursor", kwargs.get("cursor", {}))])
-            cursor = self._command(sock_info, cmd, slave_okay)["cursor"]
+            cursor = self._command(sock_info, cmd, subordinate_okay)["cursor"]
             return CommandCursor(coll, cursor, sock_info.address)
 
     def list_collections(self, session=None, **kwargs):
@@ -671,9 +671,9 @@ class Database(common.BaseObject):
         read_pref = ((session and session._txn_read_preference())
                      or ReadPreference.PRIMARY)
         with self.__client._socket_for_reads(
-                read_pref) as (sock_info, slave_okay):
+                read_pref) as (sock_info, subordinate_okay):
             return self._list_collections(
-                sock_info, slave_okay, session, read_preference=read_pref,
+                sock_info, subordinate_okay, session, read_preference=read_pref,
                 **kwargs)
 
     def list_collection_names(self, session=None):
@@ -933,7 +933,7 @@ class Database(common.BaseObject):
         error_msg = error.get("err", "")
         if error_msg is None:
             return None
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             # Reset primary server and request check, if another thread isn't
             # doing so already.
             primary = self.__client.primary

--- a/venv/lib/python3.7/site-packages/pymongo/errors.py
+++ b/venv/lib/python3.7/site-packages/pymongo/errors.py
@@ -85,8 +85,8 @@ class NetworkTimeout(AutoReconnect):
     """
 
 
-class NotMasterError(AutoReconnect):
-    """The server responded "not master" or "node is recovering".
+class NotMainError(AutoReconnect):
+    """The server responded "not main" or "node is recovering".
 
     These errors result from a query, write, or command. The operation failed
     because the client thought it was using the primary but the primary has

--- a/venv/lib/python3.7/site-packages/pymongo/helpers.py
+++ b/venv/lib/python3.7/site-packages/pymongo/helpers.py
@@ -23,20 +23,20 @@ from pymongo import ASCENDING
 from pymongo.errors import (CursorNotFound,
                             DuplicateKeyError,
                             ExecutionTimeout,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure,
                             WriteError,
                             WriteConcernError,
                             WTimeoutError)
 
-# From the Server Discovery and Monitoring spec, the "not master" error codes
+# From the Server Discovery and Monitoring spec, the "not main" error codes
 # are combined with the "node is recovering" error codes.
 _NOT_MASTER_CODES = frozenset([
-    10107,  # NotMaster
-    13435,  # NotMasterNoSlaveOk
+    10107,  # NotMain
+    13435,  # NotMainNoSubordinateOk
     11600,  # InterruptedAtShutdown
     11602,  # InterruptedDueToReplStateChange
-    13436,  # NotMasterOrSecondary
+    13436,  # NotMainOrSecondary
     189,    # PrimarySteppedDown
     91,     # ShutdownInProgress
 ])
@@ -127,12 +127,12 @@ def _check_command_response(response, msg=None, allowable_errors=None,
         if allowable_errors is None or errmsg not in allowable_errors:
 
             code = details.get("code")
-            # Server is "not master" or "recovering"
+            # Server is "not main" or "recovering"
             if code in _NOT_MASTER_CODES:
-                raise NotMasterError(errmsg, response)
-            elif ("not master" in errmsg
+                raise NotMainError(errmsg, response)
+            elif ("not main" in errmsg
                   or "node is recovering" in errmsg):
-                raise NotMasterError(errmsg, response)
+                raise NotMainError(errmsg, response)
 
             # Server assertion failures
             if errmsg == "db assertion failure":
@@ -172,8 +172,8 @@ def _check_gle_response(result):
     if error_msg is None:
         return result
 
-    if error_msg.startswith("not master"):
-        raise NotMasterError(error_msg, result)
+    if error_msg.startswith("not main"):
+        raise NotMainError(error_msg, result)
 
     details = result
 

--- a/venv/lib/python3.7/site-packages/pymongo/ismaster.py
+++ b/venv/lib/python3.7/site-packages/pymongo/ismaster.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parse a response to the 'ismaster' command."""
+"""Parse a response to the 'ismain' command."""
 
 import itertools
 
@@ -22,7 +22,7 @@ from pymongo.server_type import SERVER_TYPE
 
 
 def _get_server_type(doc):
-    """Determine the server type from an ismaster response."""
+    """Determine the server type from an ismain response."""
     if not doc.get('ok'):
         return SERVER_TYPE.Unknown
 
@@ -31,7 +31,7 @@ def _get_server_type(doc):
     elif doc.get('setName'):
         if doc.get('hidden'):
             return SERVER_TYPE.RSOther
-        elif doc.get('ismaster'):
+        elif doc.get('ismain'):
             return SERVER_TYPE.RSPrimary
         elif doc.get('secondary'):
             return SERVER_TYPE.RSSecondary
@@ -45,11 +45,11 @@ def _get_server_type(doc):
         return SERVER_TYPE.Standalone
 
 
-class IsMaster(object):
+class IsMain(object):
     __slots__ = ('_doc', '_server_type', '_is_writable', '_is_readable')
 
     def __init__(self, doc):
-        """Parse an ismaster response from the server."""
+        """Parse an ismain response from the server."""
         self._server_type = _get_server_type(doc)
         self._doc = doc
         self._is_writable = self._server_type in (
@@ -63,7 +63,7 @@ class IsMaster(object):
 
     @property
     def document(self):
-        """The complete ismaster command response document.
+        """The complete ismain command response document.
 
         .. versionadded:: 3.4
         """

--- a/venv/lib/python3.7/site-packages/pymongo/message.py
+++ b/venv/lib/python3.7/site-packages/pymongo/message.py
@@ -43,7 +43,7 @@ from pymongo.errors import (ConfigurationError,
                             DocumentTooLarge,
                             ExecutionTimeout,
                             InvalidOperation,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure,
                             ProtocolError)
 from pymongo.read_concern import DEFAULT_READ_CONCERN
@@ -98,7 +98,7 @@ def _maybe_add_read_preference(spec, read_preference):
     # problems with mongos versions that don't support read preferences. Also,
     # for maximum backwards compatibility, don't add $readPreference for
     # secondaryPreferred unless tags or maxStalenessSeconds are in use (setting
-    # the slaveOkay bit has the same effect).
+    # the subordinateOkay bit has the same effect).
     if mode and (
         mode != ReadPreference.SECONDARY_PREFERRED.mode
         or tag_sets != [{}]
@@ -302,10 +302,10 @@ class _Query(object):
         self._as_command = cmd, self.db
         return self._as_command
 
-    def get_message(self, set_slave_ok, sock_info, use_cmd=False):
-        """Get a query message, possibly setting the slaveOk bit."""
-        if set_slave_ok:
-            # Set the slaveOk bit.
+    def get_message(self, set_subordinate_ok, sock_info, use_cmd=False):
+        """Get a query message, possibly setting the subordinateOk bit."""
+        if set_subordinate_ok:
+            # Set the subordinateOk bit.
             flags = self.flags | 4
         else:
             flags = self.flags
@@ -318,7 +318,7 @@ class _Query(object):
             if sock_info.op_msg_enabled:
                 request_id, msg, size, _ = _op_msg(
                     0, spec, self.db, self.read_preference,
-                    set_slave_ok, False, self.codec_options,
+                    set_subordinate_ok, False, self.codec_options,
                     ctx=sock_info.compression_context)
                 return request_id, msg, size
             ns = _UJOIN % (self.db, "$cmd")
@@ -413,20 +413,20 @@ class _RawBatchQuery(_Query):
 
         return False
 
-    def get_message(self, set_slave_ok, sock_info, use_cmd=False):
+    def get_message(self, set_subordinate_ok, sock_info, use_cmd=False):
         # Always pass False for use_cmd.
         return super(_RawBatchQuery, self).get_message(
-            set_slave_ok, sock_info, False)
+            set_subordinate_ok, sock_info, False)
 
 
 class _RawBatchGetMore(_GetMore):
     def use_command(self, socket_info, exhaust):
         return False
 
-    def get_message(self, set_slave_ok, sock_info, use_cmd=False):
+    def get_message(self, set_subordinate_ok, sock_info, use_cmd=False):
         # Always pass False for use_cmd.
         return super(_RawBatchGetMore, self).get_message(
-            set_slave_ok, sock_info, False)
+            set_subordinate_ok, sock_info, False)
 
 
 class _CursorAddress(tuple):
@@ -654,12 +654,12 @@ if _use_c:
     _op_msg_uncompressed = _cmessage._op_msg
 
 
-def _op_msg(flags, command, dbname, read_preference, slave_ok, check_keys,
+def _op_msg(flags, command, dbname, read_preference, subordinate_ok, check_keys,
             opts, ctx=None):
     """Get a OP_MSG message."""
     command['$db'] = dbname
     if "$readPreference" not in command:
-        if slave_ok and not read_preference.mode:
+        if subordinate_ok and not read_preference.mode:
             command["$readPreference"] = (
                 ReadPreference.PRIMARY_PREFERRED.document)
         else:
@@ -1364,7 +1364,7 @@ class _OpReply(object):
 
         Check the response for errors and unpack.
 
-        Can raise CursorNotFound, NotMasterError, ExecutionTimeout, or
+        Can raise CursorNotFound, NotMainError, ExecutionTimeout, or
         OperationFailure.
 
         :Parameters:
@@ -1386,8 +1386,8 @@ class _OpReply(object):
             error_object = bson.BSON(self.documents).decode()
             # Fake the ok field if it doesn't exist.
             error_object.setdefault("ok", 0)
-            if error_object["$err"].startswith("not master"):
-                raise NotMasterError(error_object["$err"], error_object)
+            if error_object["$err"].startswith("not main"):
+                raise NotMainError(error_object["$err"], error_object)
             elif error_object.get("code") == 50:
                 raise ExecutionTimeout(error_object.get("$err"),
                                        error_object.get("code"),
@@ -1405,7 +1405,7 @@ class _OpReply(object):
         Check the response for errors and unpack, returning a dictionary
         containing the response data.
 
-        Can raise CursorNotFound, NotMasterError, ExecutionTimeout, or
+        Can raise CursorNotFound, NotMainError, ExecutionTimeout, or
         OperationFailure.
 
         :Parameters:
@@ -1492,7 +1492,7 @@ _UNPACK_REPLY = {
 
 
 def _first_batch(sock_info, db, coll, query, ntoreturn,
-                 slave_ok, codec_options, read_preference, cmd, listeners):
+                 subordinate_ok, codec_options, read_preference, cmd, listeners):
     """Simple query helper for retrieving a first (and possibly only) batch."""
     query = _Query(
         0, db, coll, 0, query, None, codec_options,
@@ -1504,7 +1504,7 @@ def _first_batch(sock_info, db, coll, query, ntoreturn,
     if publish:
         start = datetime.datetime.now()
 
-    request_id, msg, max_doc_size = query.get_message(slave_ok, sock_info)
+    request_id, msg, max_doc_size = query.get_message(subordinate_ok, sock_info)
 
     if publish:
         encoding_duration = datetime.datetime.now() - start
@@ -1519,7 +1519,7 @@ def _first_batch(sock_info, db, coll, query, ntoreturn,
     except Exception as exc:
         if publish:
             duration = (datetime.datetime.now() - start) + encoding_duration
-            if isinstance(exc, (NotMasterError, OperationFailure)):
+            if isinstance(exc, (NotMainError, OperationFailure)):
                 failure = exc.details
             else:
                 failure = _convert_exception(exc)

--- a/venv/lib/python3.7/site-packages/pymongo/mongo_client.py
+++ b/venv/lib/python3.7/site-packages/pymongo/mongo_client.py
@@ -60,7 +60,7 @@ from pymongo.errors import (AutoReconnect,
                             ConnectionFailure,
                             InvalidOperation,
                             NetworkTimeout,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure,
                             PyMongoError,
                             ServerSelectionTimeoutError)
@@ -160,8 +160,8 @@ class MongoClient(common.BaseObject):
             from pymongo.errors import ConnectionFailure
             client = MongoClient()
             try:
-                # The ismaster command is cheap and does not require auth.
-                client.admin.command('ismaster')
+                # The ismain command is cheap and does not require auth.
+                client.admin.command('ismain')
             except ConnectionFailure:
                 print("Server not available")
 
@@ -979,7 +979,7 @@ class MongoClient(common.BaseObject):
             # Use SocketInfo.command directly to avoid implicitly creating
             # another session.
             with self._socket_for_reads(
-                    ReadPreference.PRIMARY_PREFERRED) as (sock_info, slave_ok):
+                    ReadPreference.PRIMARY_PREFERRED) as (sock_info, subordinate_ok):
                 if not sock_info.supports_sessions:
                     return
 
@@ -987,7 +987,7 @@ class MongoClient(common.BaseObject):
                     spec = SON([('endSessions',
                                  session_ids[i:i + common._MAX_END_SESSIONS])])
                     sock_info.command(
-                        'admin', spec, slave_ok=slave_ok, client=self)
+                        'admin', spec, subordinate_ok=subordinate_ok, client=self)
         except PyMongoError:
             # Drivers MUST ignore any errors returned by the endSessions
             # command.
@@ -1063,8 +1063,8 @@ class MongoClient(common.BaseObject):
             # operation fails because of any network error besides a socket
             # timeout...."
             raise
-        except NotMasterError:
-            # "When the client sees a "not master" error it MUST replace the
+        except NotMainError:
+            # "When the client sees a "not main" error it MUST replace the
             # server's description with type Unknown. It MUST request an
             # immediate check of the server."
             self._reset_server_and_request_check(server.description.address)
@@ -1089,7 +1089,7 @@ class MongoClient(common.BaseObject):
     def _socket_for_reads(self, read_preference):
         assert read_preference is not None, "read_preference must not be None"
         # Get a socket for a server matching the read preference, and yield
-        # sock_info, slave_ok. Server Selection Spec: "slaveOK must be sent to
+        # sock_info, subordinate_ok. Server Selection Spec: "subordinateOK must be sent to
         # mongods with topology type Single. If the server type is Mongos,
         # follow the rules for passing read preference to mongos, even for
         # topology type Single."
@@ -1099,9 +1099,9 @@ class MongoClient(common.BaseObject):
         server = topology.select_server(read_preference)
 
         with self._get_socket(server) as sock_info:
-            slave_ok = (single and not sock_info.is_mongos) or (
+            subordinate_ok = (single and not sock_info.is_mongos) or (
                 read_preference != ReadPreference.PRIMARY)
-            yield sock_info, slave_ok
+            yield sock_info, subordinate_ok
 
     def _send_message_with_response(self, operation, exhaust=False,
                                     address=None):
@@ -1128,9 +1128,9 @@ class MongoClient(common.BaseObject):
         else:
             server = topology.select_server(operation.read_preference)
 
-        # If this is a direct connection to a mongod, *always* set the slaveOk
+        # If this is a direct connection to a mongod, *always* set the subordinateOk
         # bit. See bullet point 2 in server-selection.rst#topology-type-single.
-        set_slave_ok = (
+        set_subordinate_ok = (
             topology.description.topology_type == TOPOLOGY_TYPE.Single
             and server.description.server_type != SERVER_TYPE.Mongos) or (
                 operation.read_preference != ReadPreference.PRIMARY)
@@ -1139,7 +1139,7 @@ class MongoClient(common.BaseObject):
             server,
             server.send_message_with_response,
             operation,
-            set_slave_ok,
+            set_subordinate_ok,
             self.__all_credentials,
             self._event_listeners,
             exhaust)

--- a/venv/lib/python3.7/site-packages/pymongo/monitor.py
+++ b/venv/lib/python3.7/site-packages/pymongo/monitor.py
@@ -102,11 +102,11 @@ class Monitor(object):
             self.close()
 
     def _check_with_retry(self):
-        """Call ismaster once or twice. Reset server's pool on error.
+        """Call ismain once or twice. Reset server's pool on error.
 
         Returns a ServerDescription.
         """
-        # According to the spec, if an ismaster call fails we reset the
+        # According to the spec, if an ismain call fails we reset the
         # server's pool. If a server was once connected, change its type
         # to Unknown only after retrying once.
         address = self._server_description.address
@@ -147,7 +147,7 @@ class Monitor(object):
                 return default
 
     def _check_once(self):
-        """A single attempt to call ismaster.
+        """A single attempt to call ismain.
 
         Returns a ServerDescription, or raises an exception.
         """
@@ -159,7 +159,7 @@ class Monitor(object):
             self._avg_round_trip_time.add_sample(round_trip_time)
             sd = ServerDescription(
                 address=address,
-                ismaster=response,
+                ismain=response,
                 round_trip_time=self._avg_round_trip_time.get())
             if self._publish:
                 self._listeners.publish_server_heartbeat_succeeded(
@@ -168,17 +168,17 @@ class Monitor(object):
             return sd
 
     def _check_with_socket(self, sock_info):
-        """Return (IsMaster, round_trip_time).
+        """Return (IsMain, round_trip_time).
 
         Can raise ConnectionFailure or OperationFailure.
         """
         start = _time()
         try:
-            return (sock_info.ismaster(self._pool.opts.metadata,
+            return (sock_info.ismain(self._pool.opts.metadata,
                                        self._topology.max_cluster_time()),
                     _time() - start)
         except OperationFailure as exc:
-            # Update max cluster time even when isMaster fails.
+            # Update max cluster time even when isMain fails.
             self._topology.receive_cluster_time(
                 exc.details.get('$clusterTime'))
             raise

--- a/venv/lib/python3.7/site-packages/pymongo/monitoring.py
+++ b/venv/lib/python3.7/site-packages/pymongo/monitoring.py
@@ -631,7 +631,7 @@ class ServerHeartbeatSucceededEvent(_ServerHeartbeatEvent):
 
     @property
     def reply(self):
-        """An instance of :class:`~pymongo.ismaster.IsMaster`."""
+        """An instance of :class:`~pymongo.ismain.IsMain`."""
         return self.__reply
 
 

--- a/venv/lib/python3.7/site-packages/pymongo/network.py
+++ b/venv/lib/python3.7/site-packages/pymongo/network.py
@@ -40,7 +40,7 @@ from pymongo import helpers, message
 from pymongo.common import MAX_MESSAGE_SIZE
 from pymongo.compression_support import decompress, _NO_COMPRESSION
 from pymongo.errors import (AutoReconnect,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure,
                             ProtocolError)
 from pymongo.message import _UNPACK_REPLY
@@ -49,7 +49,7 @@ from pymongo.message import _UNPACK_REPLY
 _UNPACK_HEADER = struct.Struct("<iiii").unpack
 
 
-def command(sock, dbname, spec, slave_ok, is_mongos,
+def command(sock, dbname, spec, subordinate_ok, is_mongos,
             read_preference, codec_options, session, client, check=True,
             allowable_errors=None, address=None,
             check_keys=False, listeners=None, max_bson_size=None,
@@ -65,7 +65,7 @@ def command(sock, dbname, spec, slave_ok, is_mongos,
       - `sock`: a raw socket instance
       - `dbname`: name of the database on which to run the command
       - `spec`: a command document as an ordered dict type, eg SON.
-      - `slave_ok`: whether to set the SlaveOkay wire protocol bit
+      - `subordinate_ok`: whether to set the SubordinateOkay wire protocol bit
       - `is_mongos`: are we connected to a mongos?
       - `read_preference`: a read preference
       - `codec_options`: a CodecOptions instance
@@ -84,7 +84,7 @@ def command(sock, dbname, spec, slave_ok, is_mongos,
     """
     name = next(iter(spec))
     ns = dbname + '.$cmd'
-    flags = 4 if slave_ok else 0
+    flags = 4 if subordinate_ok else 0
 
     # Publish the original command document, perhaps with lsid and $clusterTime.
     orig = spec
@@ -110,7 +110,7 @@ def command(sock, dbname, spec, slave_ok, is_mongos,
     if use_op_msg:
         flags = 2 if unacknowledged else 0
         request_id, msg, size, max_doc_size = message._op_msg(
-            flags, spec, dbname, read_preference, slave_ok, check_keys,
+            flags, spec, dbname, read_preference, subordinate_ok, check_keys,
             codec_options, ctx=compression_ctx)
         # If this is an unacknowledged write then make sure the encoded doc(s)
         # are small enough, otherwise rely on the server to return an error.
@@ -151,7 +151,7 @@ def command(sock, dbname, spec, slave_ok, is_mongos,
     except Exception as exc:
         if publish:
             duration = (datetime.datetime.now() - start) + encoding_duration
-            if isinstance(exc, (NotMasterError, OperationFailure)):
+            if isinstance(exc, (NotMainError, OperationFailure)):
                 failure = exc.details
             else:
                 failure = message._convert_exception(exc)

--- a/venv/lib/python3.7/site-packages/pymongo/pool.py
+++ b/venv/lib/python3.7/site-packages/pymongo/pool.py
@@ -52,9 +52,9 @@ from pymongo.errors import (AutoReconnect,
                             InvalidOperation,
                             DocumentTooLarge,
                             NetworkTimeout,
-                            NotMasterError,
+                            NotMainError,
                             OperationFailure)
-from pymongo.ismaster import IsMaster
+from pymongo.ismain import IsMain
 from pymongo.monotonic import time as _time
 from pymongo.network import (command,
                              receive_message,
@@ -421,13 +421,13 @@ class PoolOptions(object):
 
     @property
     def appname(self):
-        """The application name, for sending with ismaster in server handshake.
+        """The application name, for sending with ismain in server handshake.
         """
         return self.__appname
 
     @property
     def driver(self):
-        """Driver name and version, for sending with ismaster in handshake.
+        """Driver name and version, for sending with ismain in handshake.
         """
         return self.__driver
 
@@ -473,8 +473,8 @@ class SocketInfo(object):
         # created before the last reset.
         self.pool_id = pool.pool_id
 
-    def ismaster(self, metadata, cluster_time):
-        cmd = SON([('ismaster', 1)])
+    def ismain(self, metadata, cluster_time):
+        cmd = SON([('ismain', 1)])
         if not self.performed_handshake:
             cmd['client'] = metadata
             if self.compression_settings:
@@ -483,25 +483,25 @@ class SocketInfo(object):
         if self.max_wire_version >= 6 and cluster_time is not None:
             cmd['$clusterTime'] = cluster_time
 
-        ismaster = IsMaster(self.command('admin', cmd, publish_events=False))
-        self.is_writable = ismaster.is_writable
-        self.max_wire_version = ismaster.max_wire_version
-        self.max_bson_size = ismaster.max_bson_size
-        self.max_message_size = ismaster.max_message_size
-        self.max_write_batch_size = ismaster.max_write_batch_size
+        ismain = IsMain(self.command('admin', cmd, publish_events=False))
+        self.is_writable = ismain.is_writable
+        self.max_wire_version = ismain.max_wire_version
+        self.max_bson_size = ismain.max_bson_size
+        self.max_message_size = ismain.max_message_size
+        self.max_write_batch_size = ismain.max_write_batch_size
         self.supports_sessions = (
-            ismaster.logical_session_timeout_minutes is not None)
-        self.is_mongos = ismaster.server_type == SERVER_TYPE.Mongos
+            ismain.logical_session_timeout_minutes is not None)
+        self.is_mongos = ismain.server_type == SERVER_TYPE.Mongos
         if not self.performed_handshake and self.compression_settings:
             ctx = self.compression_settings.get_compression_context(
-                ismaster.compressors)
+                ismain.compressors)
             self.compression_context = ctx
 
         self.performed_handshake = True
-        self.op_msg_enabled = ismaster.max_wire_version >= 6
-        return ismaster
+        self.op_msg_enabled = ismain.max_wire_version >= 6
+        return ismain
 
-    def command(self, dbname, spec, slave_ok=False,
+    def command(self, dbname, spec, subordinate_ok=False,
                 read_preference=ReadPreference.PRIMARY,
                 codec_options=DEFAULT_CODEC_OPTIONS, check=True,
                 allowable_errors=None, check_keys=False,
@@ -518,7 +518,7 @@ class SocketInfo(object):
         :Parameters:
           - `dbname`: name of the database on which to run the command
           - `spec`: a command document as a dict, SON, or mapping object
-          - `slave_ok`: whether to set the SlaveOkay wire protocol bit
+          - `subordinate_ok`: whether to set the SubordinateOkay wire protocol bit
           - `read_preference`: a read preference
           - `codec_options`: a CodecOptions instance
           - `check`: raise OperationFailure if there are errors
@@ -567,7 +567,7 @@ class SocketInfo(object):
         if self.op_msg_enabled:
             self._raise_if_not_writable(unacknowledged)
         try:
-            return command(self.sock, dbname, spec, slave_ok,
+            return command(self.sock, dbname, spec, subordinate_ok,
                            self.is_mongos, read_preference, codec_options,
                            session, client, check, allowable_errors,
                            self.address, check_keys, listeners,
@@ -612,12 +612,12 @@ class SocketInfo(object):
             self._raise_connection_failure(error)
 
     def _raise_if_not_writable(self, unacknowledged):
-        """Raise NotMasterError on unacknowledged write if this socket is not
+        """Raise NotMainError on unacknowledged write if this socket is not
         writable.
         """
         if unacknowledged and not self.is_writable:
-            # Write won't succeed, bail as if we'd received a not master error.
-            raise NotMasterError("not master")
+            # Write won't succeed, bail as if we'd received a not main error.
+            raise NotMainError("not main")
 
     def legacy_write(self, request_id, msg, max_doc_size, with_last_error):
         """Send OP_INSERT, etc., optionally returning response as a dict.
@@ -651,7 +651,7 @@ class SocketInfo(object):
         reply = self.receive_message(request_id)
         result = reply.command_response()
 
-        # Raises NotMasterError or OperationFailure.
+        # Raises NotMainError or OperationFailure.
         helpers._check_command_response(result)
         return result
 
@@ -889,7 +889,7 @@ class Pool:
         :Parameters:
           - `address`: a (hostname, port) tuple
           - `options`: a PoolOptions instance
-          - `handshake`: whether to call ismaster for each new SocketInfo
+          - `handshake`: whether to call ismain for each new SocketInfo
         """
         # Check a socket's health with socket_closed() every once in a while.
         # Can override for testing: 0 to always check, None to never check.
@@ -973,7 +973,7 @@ class Pool:
 
         sock_info = SocketInfo(sock, self, self.address)
         if self.handshake:
-            sock_info.ismaster(self.opts.metadata, None)
+            sock_info.ismain(self.opts.metadata, None)
         return sock_info
 
     @contextlib.contextmanager

--- a/venv/lib/python3.7/site-packages/pymongo/read_preferences.py
+++ b/venv/lib/python3.7/site-packages/pymongo/read_preferences.py
@@ -452,7 +452,7 @@ class MovingAverage(object):
 
     def add_sample(self, sample):
         if sample < 0:
-            # Likely system time change while waiting for ismaster response
+            # Likely system time change while waiting for ismain response
             # and not using time.monotonic. Ignore it, the next one will
             # probably be valid.
             return

--- a/venv/lib/python3.7/site-packages/pymongo/server.py
+++ b/venv/lib/python3.7/site-packages/pymongo/server.py
@@ -66,7 +66,7 @@ class Server(object):
     def send_message_with_response(
             self,
             operation,
-            set_slave_okay,
+            set_subordinate_okay,
             all_credentials,
             listeners,
             exhaust=False):
@@ -76,7 +76,7 @@ class Server(object):
 
         :Parameters:
           - `operation`: A _Query or _GetMore object.
-          - `set_slave_okay`: Pass to operation.get_message.
+          - `set_subordinate_okay`: Pass to operation.get_message.
           - `all_credentials`: dict, maps auth source to MongoCredential.
           - `listeners`: Instance of _EventListeners or None.
           - `exhaust` (optional): If True, the socket used stays checked out.
@@ -91,7 +91,7 @@ class Server(object):
 
             use_find_cmd = operation.use_command(sock_info, exhaust)
             message = operation.get_message(
-                set_slave_okay, sock_info, use_find_cmd)
+                set_subordinate_okay, sock_info, use_find_cmd)
             request_id, data, max_doc_size = self._split_message(message)
 
             if publish:

--- a/venv/lib/python3.7/site-packages/pymongo/server_description.py
+++ b/venv/lib/python3.7/site-packages/pymongo/server_description.py
@@ -16,7 +16,7 @@
 
 from bson import EPOCH_NAIVE
 from pymongo.server_type import SERVER_TYPE
-from pymongo.ismaster import IsMaster
+from pymongo.ismain import IsMain
 from pymongo.monotonic import time as _time
 
 
@@ -35,7 +35,7 @@ class ServerDescription(object):
 
     :Parameters:
       - `address`: A (host, port) pair
-      - `ismaster`: Optional IsMaster instance
+      - `ismain`: Optional IsMain instance
       - `round_trip_time`: Optional float
       - `error`: Optional, the last error attempting to connect to the server
     """
@@ -51,37 +51,37 @@ class ServerDescription(object):
     def __init__(
             self,
             address,
-            ismaster=None,
+            ismain=None,
             round_trip_time=None,
             error=None):
         self._address = address
-        if not ismaster:
-            ismaster = IsMaster({})
+        if not ismain:
+            ismain = IsMain({})
 
-        self._server_type = ismaster.server_type
-        self._all_hosts = ismaster.all_hosts
-        self._tags = ismaster.tags
-        self._replica_set_name = ismaster.replica_set_name
-        self._primary = ismaster.primary
-        self._max_bson_size = ismaster.max_bson_size
-        self._max_message_size = ismaster.max_message_size
-        self._max_write_batch_size = ismaster.max_write_batch_size
-        self._min_wire_version = ismaster.min_wire_version
-        self._max_wire_version = ismaster.max_wire_version
-        self._set_version = ismaster.set_version
-        self._election_id = ismaster.election_id
-        self._cluster_time = ismaster.cluster_time
-        self._is_writable = ismaster.is_writable
-        self._is_readable = ismaster.is_readable
-        self._ls_timeout_minutes = ismaster.logical_session_timeout_minutes
+        self._server_type = ismain.server_type
+        self._all_hosts = ismain.all_hosts
+        self._tags = ismain.tags
+        self._replica_set_name = ismain.replica_set_name
+        self._primary = ismain.primary
+        self._max_bson_size = ismain.max_bson_size
+        self._max_message_size = ismain.max_message_size
+        self._max_write_batch_size = ismain.max_write_batch_size
+        self._min_wire_version = ismain.min_wire_version
+        self._max_wire_version = ismain.max_wire_version
+        self._set_version = ismain.set_version
+        self._election_id = ismain.election_id
+        self._cluster_time = ismain.cluster_time
+        self._is_writable = ismain.is_writable
+        self._is_readable = ismain.is_readable
+        self._ls_timeout_minutes = ismain.logical_session_timeout_minutes
         self._round_trip_time = round_trip_time
-        self._me = ismaster.me
+        self._me = ismain.me
         self._last_update_time = _time()
         self._error = error
 
-        if ismaster.last_write_date:
+        if ismain.last_write_date:
             # Convert from datetime to seconds.
-            delta = ismaster.last_write_date - EPOCH_NAIVE
+            delta = ismain.last_write_date - EPOCH_NAIVE
             self._last_write_date = _total_seconds(delta)
         else:
             self._last_write_date = None

--- a/venv/lib/python3.7/site-packages/pymongo/topology.py
+++ b/venv/lib/python3.7/site-packages/pymongo/topology.py
@@ -275,10 +275,10 @@ class Topology(object):
         self._condition.notify_all()
 
     def on_change(self, server_description):
-        """Process a new ServerDescription after an ismaster call completes."""
+        """Process a new ServerDescription after an ismain call completes."""
         # We do no I/O holding the lock.
         with self._lock:
-            # Monitors may continue working on ismaster calls for some time
+            # Monitors may continue working on ismain calls for some time
             # after a call to Topology.close, so this method may be called at
             # any time. Ensure the topology is open before processing the
             # change.

--- a/venv/lib/python3.7/site-packages/pymongo/topology_description.py
+++ b/venv/lib/python3.7/site-packages/pymongo/topology_description.py
@@ -95,7 +95,7 @@ class TopologyDescription(object):
                 break
 
         # Server Discovery And Monitoring Spec: Whenever a client updates the
-        # TopologyDescription from an ismaster response, it MUST set
+        # TopologyDescription from an ismain response, it MUST set
         # TopologyDescription.logicalSessionTimeoutMinutes to the smallest
         # logicalSessionTimeoutMinutes value among ServerDescriptions of all
         # data-bearing server types. If any have a null
@@ -280,7 +280,7 @@ class TopologyDescription(object):
         return self.has_readable_server(ReadPreference.PRIMARY)
 
 
-# If topology type is Unknown and we receive an ismaster response, what should
+# If topology type is Unknown and we receive an ismain response, what should
 # the new topology type be?
 _SERVER_TYPE_TO_TOPOLOGY_TYPE = {
     SERVER_TYPE.Mongos: TOPOLOGY_TYPE.Sharded,
@@ -297,9 +297,9 @@ def updated_topology_description(topology_description, server_description):
     :Parameters:
       - `topology_description`: the current TopologyDescription
       - `server_description`: a new ServerDescription that resulted from
-        an ismaster call
+        an ismain call
 
-    Called after attempting (successfully or not) to call ismaster on the
+    Called after attempting (successfully or not) to call ismain on the
     server at server_description.address. Does not modify topology_description.
     """
     address = server_description.address
@@ -401,7 +401,7 @@ def _update_rs_from_primary(
         server_description,
         max_set_version,
         max_election_id):
-    """Update topology description from a primary's ismaster response.
+    """Update topology description from a primary's ismain response.
 
     Pass in a dict of ServerDescriptions, current replica set name, the
     ServerDescription we are processing, and the TopologyDescription's

--- a/venv/lib/python3.7/site-packages/pymongo/uri_parser.py
+++ b/venv/lib/python3.7/site-packages/pymongo/uri_parser.py
@@ -158,7 +158,7 @@ def parse_host(entity, default_port=DEFAULT_PORT):
     # Normalize hostname to lowercase, since DNS is case-insensitive:
     # http://tools.ietf.org/html/rfc4343
     # This prevents useless rediscovery if "foo.com" is in the seed list but
-    # "FOO.com" is in the ismaster response.
+    # "FOO.com" is in the ismain response.
     return host.lower(), port
 
 

--- a/venv/lib/python3.7/site-packages/redis/client.py
+++ b/venv/lib/python3.7/site-packages/redis/client.py
@@ -131,7 +131,7 @@ def parse_info(response):
 
 
 SENTINEL_STATE_TYPES = {
-    'can-failover-its-master': int,
+    'can-failover-its-main': int,
     'config-epoch': int,
     'down-after-milliseconds': int,
     'failover-timeout': int,
@@ -140,10 +140,10 @@ SENTINEL_STATE_TYPES = {
     'last-ok-ping-reply': int,
     'last-ping-reply': int,
     'last-ping-sent': int,
-    'master-link-down-time': int,
-    'master-port': int,
+    'main-link-down-time': int,
+    'main-port': int,
     'num-other-sentinels': int,
-    'num-slaves': int,
+    'num-subordinates': int,
     'o-down-time': int,
     'pending-commands': int,
     'parallel-syncs': int,
@@ -151,8 +151,8 @@ SENTINEL_STATE_TYPES = {
     'quorum': int,
     'role-reported-time': int,
     's-down-time': int,
-    'slave-priority': int,
-    'slave-repl-offset': int,
+    'subordinate-priority': int,
+    'subordinate-repl-offset': int,
     'voted-leader-epoch': int
 }
 
@@ -160,20 +160,20 @@ SENTINEL_STATE_TYPES = {
 def parse_sentinel_state(item):
     result = pairs_to_dict_typed(item, SENTINEL_STATE_TYPES)
     flags = set(result['flags'].split(','))
-    for name, flag in (('is_master', 'master'), ('is_slave', 'slave'),
+    for name, flag in (('is_main', 'main'), ('is_subordinate', 'subordinate'),
                        ('is_sdown', 's_down'), ('is_odown', 'o_down'),
                        ('is_sentinel', 'sentinel'),
                        ('is_disconnected', 'disconnected'),
-                       ('is_master_down', 'master_down')):
+                       ('is_main_down', 'main_down')):
         result[name] = flag in flags
     return result
 
 
-def parse_sentinel_master(response):
+def parse_sentinel_main(response):
     return parse_sentinel_state(imap(nativestr, response))
 
 
-def parse_sentinel_masters(response):
+def parse_sentinel_mains(response):
     result = {}
     for item in response:
         state = parse_sentinel_state(imap(nativestr, item))
@@ -181,11 +181,11 @@ def parse_sentinel_masters(response):
     return result
 
 
-def parse_sentinel_slaves_and_sentinels(response):
+def parse_sentinel_subordinates_and_sentinels(response):
     return [parse_sentinel_state(imap(nativestr, item)) for item in response]
 
 
-def parse_sentinel_get_master(response):
+def parse_sentinel_get_main(response):
     return response and (response[0], int(response[1])) or None
 
 
@@ -368,13 +368,13 @@ def parse_cluster_info(response, **options):
 
 def _parse_node_line(line):
     line_items = line.split(' ')
-    node_id, addr, flags, master_id, ping, pong, epoch, \
+    node_id, addr, flags, main_id, ping, pong, epoch, \
         connected = line.split(' ')[:8]
     slots = [sl.split('-') for sl in line_items[8:]]
     node_dict = {
         'node_id': node_id,
         'flags': flags,
-        'master_id': master_id,
+        'main_id': main_id,
         'last_ping_sent': ping,
         'last_pong_rcvd': pong,
         'epoch': epoch,
@@ -537,14 +537,14 @@ class Redis(object):
             'SCRIPT FLUSH': bool_ok,
             'SCRIPT KILL': bool_ok,
             'SCRIPT LOAD': nativestr,
-            'SENTINEL GET-MASTER-ADDR-BY-NAME': parse_sentinel_get_master,
-            'SENTINEL MASTER': parse_sentinel_master,
-            'SENTINEL MASTERS': parse_sentinel_masters,
+            'SENTINEL GET-MASTER-ADDR-BY-NAME': parse_sentinel_get_main,
+            'SENTINEL MASTER': parse_sentinel_main,
+            'SENTINEL MASTERS': parse_sentinel_mains,
             'SENTINEL MONITOR': bool_ok,
             'SENTINEL REMOVE': bool_ok,
-            'SENTINEL SENTINELS': parse_sentinel_slaves_and_sentinels,
+            'SENTINEL SENTINELS': parse_sentinel_subordinates_and_sentinels,
             'SENTINEL SET': bool_ok,
-            'SENTINEL SLAVES': parse_sentinel_slaves_and_sentinels,
+            'SENTINEL SLAVES': parse_sentinel_subordinates_and_sentinels,
             'SET': lambda r: r and nativestr(r) == 'OK',
             'SLOWLOG GET': parse_slowlog_get,
             'SLOWLOG LEN': int,
@@ -816,7 +816,7 @@ class Redis(object):
         Disconnects client(s) using a variety of filter options
         :param id: Kills a client by its unique ID field
         :param type: Kills a client by type where type is one of 'normal',
-        'master', 'slave' or 'pubsub'
+        'main', 'subordinate' or 'pubsub'
         :param addr: Kills a client by its 'address:port'
         :param skipme: If True, then the client calling the command
         will not get killed even if it is identified by one of the filter
@@ -824,7 +824,7 @@ class Redis(object):
         """
         args = []
         if _type is not None:
-            client_types = ('normal', 'master', 'slave', 'pubsub')
+            client_types = ('normal', 'main', 'subordinate', 'pubsub')
             if str(_type).lower() not in client_types:
                 raise DataError("CLIENT KILL type must be one of %r" % (
                                 client_types,))
@@ -851,12 +851,12 @@ class Redis(object):
         """
         Returns a list of currently connected clients.
         If type of client specified, only that type will be returned.
-        :param _type: optional. one of the client types (normal, master,
+        :param _type: optional. one of the client types (normal, main,
          replica, pubsub)
         """
         "Returns a list of currently connected clients"
         if _type is not None:
-            client_types = ('normal', 'master', 'replica', 'pubsub')
+            client_types = ('normal', 'main', 'replica', 'pubsub')
             if str(_type).lower() not in client_types:
                 raise DataError("CLIENT LIST _type must be one of %r" % (
                                 client_types,))
@@ -1048,25 +1048,25 @@ class Redis(object):
         warnings.warn(
             DeprecationWarning('Use the individual sentinel_* methods'))
 
-    def sentinel_get_master_addr_by_name(self, service_name):
+    def sentinel_get_main_addr_by_name(self, service_name):
         "Returns a (host, port) pair for the given ``service_name``"
         return self.execute_command('SENTINEL GET-MASTER-ADDR-BY-NAME',
                                     service_name)
 
-    def sentinel_master(self, service_name):
-        "Returns a dictionary containing the specified masters state."
+    def sentinel_main(self, service_name):
+        "Returns a dictionary containing the specified mains state."
         return self.execute_command('SENTINEL MASTER', service_name)
 
-    def sentinel_masters(self):
-        "Returns a list of dictionaries containing each master's state."
+    def sentinel_mains(self):
+        "Returns a list of dictionaries containing each main's state."
         return self.execute_command('SENTINEL MASTERS')
 
     def sentinel_monitor(self, name, ip, port, quorum):
-        "Add a new master to Sentinel to be monitored"
+        "Add a new main to Sentinel to be monitored"
         return self.execute_command('SENTINEL MONITOR', name, ip, port, quorum)
 
     def sentinel_remove(self, name):
-        "Remove a master from Sentinel's monitoring"
+        "Remove a main from Sentinel's monitoring"
         return self.execute_command('SENTINEL REMOVE', name)
 
     def sentinel_sentinels(self, service_name):
@@ -1074,11 +1074,11 @@ class Redis(object):
         return self.execute_command('SENTINEL SENTINELS', service_name)
 
     def sentinel_set(self, name, option, value):
-        "Set Sentinel monitoring parameters for a given master"
+        "Set Sentinel monitoring parameters for a given main"
         return self.execute_command('SENTINEL SET', name, option, value)
 
-    def sentinel_slaves(self, service_name):
-        "Returns a list of slaves for ``service_name``"
+    def sentinel_subordinates(self, service_name):
+        "Returns a list of subordinates for ``service_name``"
         return self.execute_command('SENTINEL SLAVES', service_name)
 
     def shutdown(self, save=False, nosave=False):
@@ -1102,11 +1102,11 @@ class Redis(object):
             return
         raise RedisError("SHUTDOWN seems to have failed.")
 
-    def slaveof(self, host=None, port=None):
+    def subordinateof(self, host=None, port=None):
         """
-        Set the server to be a replicated slave of the instance identified
+        Set the server to be a replicated subordinate of the instance identified
         by the ``host`` and ``port``. If called without arguments, the
-        instance is promoted to a master instead.
+        instance is promoted to a main instead.
         """
         if host is None and port is None:
             return self.execute_command('SLAVEOF', Token.get_token('NO'),

--- a/venv/lib/python3.7/site-packages/redis/sentinel.py
+++ b/venv/lib/python3.7/site-packages/redis/sentinel.py
@@ -8,11 +8,11 @@ from redis.exceptions import (ConnectionError, ResponseError, ReadOnlyError,
 from redis._compat import iteritems, nativestr, xrange
 
 
-class MasterNotFoundError(ConnectionError):
+class MainNotFoundError(ConnectionError):
     pass
 
 
-class SlaveNotFoundError(ConnectionError):
+class SubordinateNotFoundError(ConnectionError):
     pass
 
 
@@ -40,28 +40,28 @@ class SentinelManagedConnection(Connection):
     def connect(self):
         if self._sock:
             return  # already connected
-        if self.connection_pool.is_master:
-            self.connect_to(self.connection_pool.get_master_address())
+        if self.connection_pool.is_main:
+            self.connect_to(self.connection_pool.get_main_address())
         else:
-            for slave in self.connection_pool.rotate_slaves():
+            for subordinate in self.connection_pool.rotate_subordinates():
                 try:
-                    return self.connect_to(slave)
+                    return self.connect_to(subordinate)
                 except ConnectionError:
                     continue
-            raise SlaveNotFoundError  # Never be here
+            raise SubordinateNotFoundError  # Never be here
 
     def read_response(self):
         try:
             return super(SentinelManagedConnection, self).read_response()
         except ReadOnlyError:
-            if self.connection_pool.is_master:
-                # When talking to a master, a ReadOnlyError when likely
-                # indicates that the previous master that we're still connected
-                # to has been demoted to a slave and there's a new master.
+            if self.connection_pool.is_main:
+                # When talking to a main, a ReadOnlyError when likely
+                # indicates that the previous main that we're still connected
+                # to has been demoted to a subordinate and there's a new main.
                 # calling disconnect will force the connection to re-query
                 # sentinel during the next connect() attempt.
                 self.disconnect()
-                raise ConnectionError('The previous master is now a slave')
+                raise ConnectionError('The previous main is now a subordinate')
             raise
 
 
@@ -76,7 +76,7 @@ class SentinelConnectionPool(ConnectionPool):
     def __init__(self, service_name, sentinel_manager, **kwargs):
         kwargs['connection_class'] = kwargs.get(
             'connection_class', SentinelManagedConnection)
-        self.is_master = kwargs.pop('is_master', True)
+        self.is_main = kwargs.pop('is_main', True)
         self.check_connection = kwargs.pop('check_connection', False)
         super(SentinelConnectionPool, self).__init__(**kwargs)
         self.connection_kwargs['connection_pool'] = weakref.proxy(self)
@@ -87,42 +87,42 @@ class SentinelConnectionPool(ConnectionPool):
         return "%s<service=%s(%s)" % (
             type(self).__name__,
             self.service_name,
-            self.is_master and 'master' or 'slave',
+            self.is_main and 'main' or 'subordinate',
         )
 
     def reset(self):
         super(SentinelConnectionPool, self).reset()
-        self.master_address = None
-        self.slave_rr_counter = None
+        self.main_address = None
+        self.subordinate_rr_counter = None
 
-    def get_master_address(self):
-        master_address = self.sentinel_manager.discover_master(
+    def get_main_address(self):
+        main_address = self.sentinel_manager.discover_main(
             self.service_name)
-        if self.is_master:
-            if self.master_address is None:
-                self.master_address = master_address
-            elif master_address != self.master_address:
-                # Master address changed, disconnect all clients in this pool
+        if self.is_main:
+            if self.main_address is None:
+                self.main_address = main_address
+            elif main_address != self.main_address:
+                # Main address changed, disconnect all clients in this pool
                 self.disconnect()
-        return master_address
+        return main_address
 
-    def rotate_slaves(self):
-        "Round-robin slave balancer"
-        slaves = self.sentinel_manager.discover_slaves(self.service_name)
-        if slaves:
-            if self.slave_rr_counter is None:
-                self.slave_rr_counter = random.randint(0, len(slaves) - 1)
-            for _ in xrange(len(slaves)):
-                self.slave_rr_counter = (
-                    self.slave_rr_counter + 1) % len(slaves)
-                slave = slaves[self.slave_rr_counter]
-                yield slave
-        # Fallback to the master connection
+    def rotate_subordinates(self):
+        "Round-robin subordinate balancer"
+        subordinates = self.sentinel_manager.discover_subordinates(self.service_name)
+        if subordinates:
+            if self.subordinate_rr_counter is None:
+                self.subordinate_rr_counter = random.randint(0, len(subordinates) - 1)
+            for _ in xrange(len(subordinates)):
+                self.subordinate_rr_counter = (
+                    self.subordinate_rr_counter + 1) % len(subordinates)
+                subordinate = subordinates[self.subordinate_rr_counter]
+                yield subordinate
+        # Fallback to the main connection
         try:
-            yield self.get_master_address()
-        except MasterNotFoundError:
+            yield self.get_main_address()
+        except MainNotFoundError:
             pass
-        raise SlaveNotFoundError('No slave found for %r' % (self.service_name))
+        raise SubordinateNotFoundError('No subordinate found for %r' % (self.service_name))
 
 
 class Sentinel(object):
@@ -131,10 +131,10 @@ class Sentinel(object):
 
     >>> from redis.sentinel import Sentinel
     >>> sentinel = Sentinel([('localhost', 26379)], socket_timeout=0.1)
-    >>> master = sentinel.master_for('mymaster', socket_timeout=0.1)
-    >>> master.set('foo', 'bar')
-    >>> slave = sentinel.slave_for('mymaster', socket_timeout=0.1)
-    >>> slave.get('foo')
+    >>> main = sentinel.main_for('mymain', socket_timeout=0.1)
+    >>> main.set('foo', 'bar')
+    >>> subordinate = sentinel.subordinate_for('mymain', socket_timeout=0.1)
+    >>> subordinate.get('foo')
     'bar'
 
     ``sentinels`` is a list of sentinel nodes. Each node is represented by
@@ -182,66 +182,66 @@ class Sentinel(object):
             type(self).__name__,
             ','.join(sentinel_addresses))
 
-    def check_master_state(self, state, service_name):
-        if not state['is_master'] or state['is_sdown'] or state['is_odown']:
+    def check_main_state(self, state, service_name):
+        if not state['is_main'] or state['is_sdown'] or state['is_odown']:
             return False
         # Check if our sentinel doesn't see other nodes
         if state['num-other-sentinels'] < self.min_other_sentinels:
             return False
         return True
 
-    def discover_master(self, service_name):
+    def discover_main(self, service_name):
         """
-        Asks sentinel servers for the Redis master's address corresponding
+        Asks sentinel servers for the Redis main's address corresponding
         to the service labeled ``service_name``.
 
-        Returns a pair (address, port) or raises MasterNotFoundError if no
-        master is found.
+        Returns a pair (address, port) or raises MainNotFoundError if no
+        main is found.
         """
         for sentinel_no, sentinel in enumerate(self.sentinels):
             try:
-                masters = sentinel.sentinel_masters()
+                mains = sentinel.sentinel_mains()
             except (ConnectionError, TimeoutError):
                 continue
-            state = masters.get(service_name)
-            if state and self.check_master_state(state, service_name):
+            state = mains.get(service_name)
+            if state and self.check_main_state(state, service_name):
                 # Put this sentinel at the top of the list
                 self.sentinels[0], self.sentinels[sentinel_no] = (
                     sentinel, self.sentinels[0])
                 return state['ip'], state['port']
-        raise MasterNotFoundError("No master found for %r" % (service_name,))
+        raise MainNotFoundError("No main found for %r" % (service_name,))
 
-    def filter_slaves(self, slaves):
-        "Remove slaves that are in an ODOWN or SDOWN state"
-        slaves_alive = []
-        for slave in slaves:
-            if slave['is_odown'] or slave['is_sdown']:
+    def filter_subordinates(self, subordinates):
+        "Remove subordinates that are in an ODOWN or SDOWN state"
+        subordinates_alive = []
+        for subordinate in subordinates:
+            if subordinate['is_odown'] or subordinate['is_sdown']:
                 continue
-            slaves_alive.append((slave['ip'], slave['port']))
-        return slaves_alive
+            subordinates_alive.append((subordinate['ip'], subordinate['port']))
+        return subordinates_alive
 
-    def discover_slaves(self, service_name):
-        "Returns a list of alive slaves for service ``service_name``"
+    def discover_subordinates(self, service_name):
+        "Returns a list of alive subordinates for service ``service_name``"
         for sentinel in self.sentinels:
             try:
-                slaves = sentinel.sentinel_slaves(service_name)
+                subordinates = sentinel.sentinel_subordinates(service_name)
             except (ConnectionError, ResponseError, TimeoutError):
                 continue
-            slaves = self.filter_slaves(slaves)
-            if slaves:
-                return slaves
+            subordinates = self.filter_subordinates(subordinates)
+            if subordinates:
+                return subordinates
         return []
 
-    def master_for(self, service_name, redis_class=Redis,
+    def main_for(self, service_name, redis_class=Redis,
                    connection_pool_class=SentinelConnectionPool, **kwargs):
         """
-        Returns a redis client instance for the ``service_name`` master.
+        Returns a redis client instance for the ``service_name`` main.
 
-        A SentinelConnectionPool class is used to retrive the master's
+        A SentinelConnectionPool class is used to retrive the main's
         address before establishing a new connection.
 
-        NOTE: If the master's address has changed, any cached connections to
-        the old master are closed.
+        NOTE: If the main's address has changed, any cached connections to
+        the old main are closed.
 
         By default clients will be a redis.Redis instance. Specify a
         different class to the ``redis_class`` argument if you desire
@@ -254,18 +254,18 @@ class Sentinel(object):
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
         """
-        kwargs['is_master'] = True
+        kwargs['is_main'] = True
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
         return redis_class(connection_pool=connection_pool_class(
             service_name, self, **connection_kwargs))
 
-    def slave_for(self, service_name, redis_class=Redis,
+    def subordinate_for(self, service_name, redis_class=Redis,
                   connection_pool_class=SentinelConnectionPool, **kwargs):
         """
-        Returns redis client instance for the ``service_name`` slave(s).
+        Returns redis client instance for the ``service_name`` subordinate(s).
 
-        A SentinelConnectionPool class is used to retrive the slave's
+        A SentinelConnectionPool class is used to retrive the subordinate's
         address before establishing a new connection.
 
         By default clients will be a redis.Redis instance. Specify a
@@ -279,7 +279,7 @@ class Sentinel(object):
         passed to this class and passed to the connection pool as keyword
         arguments to be used to initialize Redis connections.
         """
-        kwargs['is_master'] = False
+        kwargs['is_main'] = False
         connection_kwargs = dict(self.connection_kwargs)
         connection_kwargs.update(kwargs)
         return redis_class(connection_pool=connection_pool_class(

--- a/venv/lib/python3.7/site-packages/requests_toolbelt/threaded/pool.py
+++ b/venv/lib/python3.7/site-packages/requests_toolbelt/threaded/pool.py
@@ -142,7 +142,7 @@ class Pool(object):
             yield resp
 
     def join_all(self):
-        """Join all the threads to the master thread."""
+        """Join all the threads to the main thread."""
         for session_thread in self._pool:
             session_thread.join()
 

--- a/venv/lib/python3.7/site-packages/requests_toolbelt/threaded/thread.py
+++ b/venv/lib/python3.7/site-packages/requests_toolbelt/threaded/thread.py
@@ -49,5 +49,5 @@ class SessionThread(object):
         return self._worker.is_alive()
 
     def join(self):
-        """Join this thread to the master thread."""
+        """Join this thread to the main thread."""
         self._worker.join()

--- a/venv/lib/python3.7/site-packages/rq/cli/helpers.py
+++ b/venv/lib/python3.7/site-packages/rq/cli/helpers.py
@@ -44,9 +44,9 @@ def get_redis_from_config(settings, connection_class=Redis):
         socket_timeout = settings['SENTINEL'].get('SOCKET_TIMEOUT', None)
         password = settings['SENTINEL'].get('PASSWORD', None)
         db = settings['SENTINEL'].get('DB', 0)
-        master_name = settings['SENTINEL'].get('MASTER_NAME', 'mymaster')
+        main_name = settings['SENTINEL'].get('MASTER_NAME', 'mymain')
         sn = Sentinel(instances, socket_timeout=socket_timeout, password=password, db=db)
-        return sn.master_for(master_name)
+        return sn.main_for(main_name)
 
     kwargs = {
         'host': settings.get('REDIS_HOST', 'localhost'),

--- a/venv/lib/python3.7/site-packages/tornado/process.py
+++ b/venv/lib/python3.7/site-packages/tornado/process.py
@@ -176,7 +176,7 @@ def fork_processes(num_processes: Optional[int], max_restarts: int = None) -> in
         new_id = start_child(id)
         if new_id is not None:
             return new_id
-    # All child processes exited cleanly, so exit the master process
+    # All child processes exited cleanly, so exit the main process
     # instead of just returning to right after the call to
     # fork_processes (which will probably just start up another IOLoop
     # unless the caller checks the return value).

--- a/venv/lib/python3.7/site-packages/tornado/test/process_test.py
+++ b/venv/lib/python3.7/site-packages/tornado/test/process_test.py
@@ -62,7 +62,7 @@ class ProcessTest(unittest.TestCase):
                 return "http://127.0.0.1:%d%s" % (port, path)
 
             # ensure that none of these processes live too long
-            signal.alarm(5)  # master process
+            signal.alarm(5)  # main process
             try:
                 id = fork_processes(3, max_restarts=3)
                 self.assertTrue(id is not None)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.